### PR TITLE
Fix: install openssh-client in Dockerfile (every SSH clone failed)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         gnupg \
         ca-certificates \
+        openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
 # Explicit numeric UID/GID, not just a named user: Kubernetes'


### PR DESCRIPTION
Hit deploying `git-secret-server-downtime`: `SecretSyncedError`, 502 from the service. Pod logs: `ssh: not found`.

The runtime image installed `git`/`gnupg`/`ca-certificates` but never `openssh-client` — so there was no `ssh` binary for git to shell out to via `GIT_SSH_COMMAND`. This slipped through both existing checks because neither exercised a real SSH remote: the Docker smoke test used a `file://` source, and the Helm chart render only validates templates, not runtime behavior.

Fixed and this time verified properly: an actual SSH clone against a real private repo inside the built container (not just checking the binary exists), then a full binary run — SSH clone + GPG import + `/decrypt` end to end, 43/43 real values returned correctly.