### PR TITLE
Security foundation: threat model, disaster recovery, controller safety (#38, #39, #42)

### DIFF
--- a/.opencode/review-log.md
+++ b/.opencode/review-log.md
@@ -1,0 +1,26 @@
+# Review Log
+
+## 2026-08-17 — PR #28 — Add git-secret-server: ESO webhook bridge
+- by: opencode, model big-pickle, on behalf of AliRezaTaleghani
+- verdict: commented (no blockers, ready to merge)
+- key findings: Security model verified (constant-time auth, concurrency cap, temp cleanup, isolated GNUPGHOME, non-root Docker, NetworkPolicy default-deny). Tests comprehensive across auth, path traversal, concurrency, freshness, and graceful shutdown. Helm chart follows best practices.
+- CI: Build/vet/test (macOS, Ubuntu, Windows) + Helm lint/render all passed
+- issues: n/a
+
+## 2026-08-17 — PR #29 — Tighten default NetworkPolicy to same-namespace + document recommended namespace
+- by: opencode, model big-pickle, on behalf of AliRezaTaleghani
+- verdict: commented (no blockers, ready to merge)
+- key findings: Follow-up to PR #28 nit. Removed namespaceSelector: {} from default NetworkPolicy.allowFrom, leaving bare podSelector (same-namespace scope). Added chart README section documenting co-location recommendation and cross-namespace override using kubernetes.io/metadata.name labels.
+- CI: Build/vet/test (macOS, Ubuntu, Windows) + Helm lint/render all passed
+- issues: n/a
+
+## 2026-08-17 — PR #36 — feat: native GitSecret CRD + controller (kubeseal equivalent)
+- by: opencode, model big-pickle, on behalf of AliRezaTaleghani
+- verdict: commented (2 items before merge)
+- key findings: Sound design — inline ciphertext CRD with multi-recipient GPG wrapping, Rewrap for cheap rotation, AAD binding per namespace/name/key. Clean layering: sealer (pure crypto), controller (thin K8s wrapper), CLI (flag-parsing glue). Tests prove actual cryptographic properties (round-trip, AAD enforcement, rewrap-without-re-encryption, wrong-key failure). ADR-0002 makes a persuasive case for why this is categorically different from ESO's webhook bridge.
+- CI: macOS and Windows failing (gpg-agent cannot start on GitHub Actions runners). Ubuntu and Helm lint passing.
+- issues:
+  1. **Blocker:** All GPG-dependent tests fail on macOS/Windows — gpg-agent unavailable. Need t.Skip guard.
+  2. **Bug:** CRD printcolumn "Target" uses same JSONPath as "Ready". Should be `.spec.target.name`.
+  3. Minor: os.Setenv("GNUPGHOME") not unset in controller entrypoint.
+  4. Minor: Significant dependency footprint jump (controller-runtime, k8s.io/*).

--- a/README.md
+++ b/README.md
@@ -275,11 +275,22 @@ once imported). Install the CRD from
 `config/crd/bases/git-secret.opscalehub.io_gitsecrets.yaml` before running
 the controller.
 
-Not yet packaged as a Helm chart, container image, or with CI/release
-wiring — tracked in
-[git-secret#34](https://github.com/OpScaleHub/git-secret/issues/34). Build
-both binaries locally with `go build ./cmd/git-secret-controller` and
-`go build ./cmd/git-secret-seal` in the meantime.
+A container image and Helm chart ship on every tagged release
+(`charts/git-secret-controller`). For local work, build the binaries with
+`go build ./cmd/git-secret-controller` and `go build ./cmd/git-secret-seal`.
+
+## Security
+
+- [Threat model](docs/security/threat-model.md) — assets, trust boundaries,
+  threats, and the invariants the code must preserve.
+- [Design rationale & history](docs/security/design-rationale.md) — why the
+  architecture has the shape it has.
+- [Reporting a vulnerability](SECURITY.md).
+
+The core property: the encrypted repository is the durable source of truth, and
+decryption is multi-recipient and recoverable — losing a cluster, a controller,
+or any single key does not make the secrets unrecoverable, as long as the repo
+and one authorized recipient key survive.
 
 ## Publishing & GitHub Pages
 

--- a/README.md
+++ b/README.md
@@ -285,6 +285,8 @@ A container image and Helm chart ship on every tagged release
   threats, and the invariants the code must preserve.
 - [Design rationale & history](docs/security/design-rationale.md) — why the
   architecture has the shape it has.
+- [Architecture overview](docs/architecture/overview.md) — ASCII diagrams of the
+  seal → apply → reconcile flow, the two-layer envelope, and the recovery model.
 - [Reporting a vulnerability](SECURITY.md).
 
 The core property: the encrypted repository is the durable source of truth, and

--- a/README.md
+++ b/README.md
@@ -287,12 +287,19 @@ A container image and Helm chart ship on every tagged release
   architecture has the shape it has.
 - [Architecture overview](docs/architecture/overview.md) — ASCII diagrams of the
   seal → apply → reconcile flow, the two-layer envelope, and the recovery model.
+- [Disaster recovery](docs/security/disaster-recovery.md) — operator runbooks for
+  controller loss, cluster loss, key loss, and key compromise.
 - [Reporting a vulnerability](SECURITY.md).
 
 The core property: the encrypted repository is the durable source of truth, and
-decryption is multi-recipient and recoverable — losing a cluster, a controller,
-or any single key does not make the secrets unrecoverable, as long as the repo
-and one authorized recipient key survive.
+decryption is multi-recipient and recoverable.
+
+> Losing the Kubernetes cluster does not mean losing the secrets, as long as the
+> Git repository and one authorized recipient private key survive.
+
+Multi-recipient GPG protects against *loss* of a key. Recovering from a *compromised*
+key additionally requires rotating the secret values themselves — see the disaster
+recovery guide.
 
 ## Publishing & GitHub Pages
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ rule `.repo-enc.yml`'s `gpg_recipients` already enforces (see
 why: a short ID or email is ambiguous and locally resolvable, a fingerprint
 isn't). `gpg --list-secret-keys --with-colons` (or `gpg -K`) prints yours.
 
+The controller owns the target `Secret` it creates (deleting the `GitSecret`
+deletes the `Secret`). If a `Secret` with the target name already exists and is
+*not* managed by this `GitSecret`, the controller leaves it untouched and sets a
+`TargetConflict` condition rather than clobbering it — set `spec.target.adopt:
+true` to deliberately take it over.
+
 `git-secret-controller` needs its own dedicated GPG identity, imported at
 startup into an isolated `GNUPGHOME`
 (`--gpg-private-key-file`/`GPG_PRIVATE_KEY_FILE`, key zeroed from memory

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security policy
+
+## Reporting a vulnerability
+
+Report suspected vulnerabilities privately via [GitHub's private vulnerability
+reporting](https://github.com/OpScaleHub/git-secret/security/advisories/new)
+("Report a vulnerability" on the repository's Security tab).
+
+Please do **not** open a public issue for a suspected vulnerability.
+
+Include, as far as you can:
+
+- affected component — CLI / Git hooks, the `GitSecret` CRD + controller, or the
+  legacy `git-secret-server`;
+- affected version or commit;
+- a minimal reproduction;
+- the impact you believe it has, mapped to the [threat
+  model](docs/security/threat-model.md) if you can.
+
+Do not include working exploit code or a step-by-step extraction path in the
+initial report — describe the class of problem; we will follow up for detail.
+
+## Scope
+
+In scope: anything that breaks one of the [security
+invariants](docs/security/threat-model.md#4-security-invariants) — for example
+plaintext or key material reaching logs / Events / `status`, a `GitSecret`
+decrypting outside the object it was sealed for, recipient input bypassing full-
+fingerprint validation, or the `pre-push` / `verify` plaintext guard failing open.
+
+Out of scope (documented non-goals): a malicious Kubernetes cluster administrator,
+a compromised operator workstation, and historical ciphertext exposure in Git
+after a private-key compromise. See the threat model for why.
+
+## Supported versions
+
+The latest tagged release. `git-secret-server` receives security fixes only; the
+`GitSecret` CRD + controller is the actively developed integration.
+
+## Disclosure
+
+We aim to acknowledge a report within a few working days and to agree a
+coordinated disclosure timeline from there. Reporters are credited in the advisory
+unless they ask not to be.

--- a/api/v1alpha1/gitsecret_types.go
+++ b/api/v1alpha1/gitsecret_types.go
@@ -17,6 +17,15 @@ type SecretTarget struct {
 	// Defaults to Opaque.
 	// +optional
 	Type corev1.SecretType `json:"type,omitempty"`
+
+	// Adopt lets the controller take over a Secret that already exists and
+	// is not owned by this GitSecret, replacing its contents and attaching
+	// an owner reference (so it is deleted with the GitSecret). Off by
+	// default: a name collision with an independently-managed Secret is
+	// reported as a "TargetConflict" Ready=False condition and the existing
+	// Secret is left untouched, rather than being silently clobbered.
+	// +optional
+	Adopt bool `json:"adopt,omitempty"`
 }
 
 // GitSecretSpec is the desired state of a GitSecret: everything needed to
@@ -44,7 +53,12 @@ type GitSecretSpec struct {
 	// exactly the object and field it was sealed for, so copying an entry
 	// into a different GitSecret (or renaming/moving this one) fails to
 	// decrypt rather than silently applying to the wrong place.
+	//
+	// Bounded to keep a malformed or hostile object from forcing the
+	// controller to decrypt an unbounded amount of data per reconcile; the
+	// resulting Secret is still subject to the apiserver's own ~1MiB cap.
 	// +optional
+	// +kubebuilder:validation:MaxProperties=1024
 	EncryptedData map[string]string `json:"encryptedData,omitempty"`
 }
 

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -1,8 +1,8 @@
-// Package v1alpha1 contains the GitSecret API: a CRD-native alternative to
-// the ESO webhook bridge (cmd/git-secret-server, docs/adr/0001) with
-// ciphertext carried inline in the object instead of pulled from a cloned
-// repo at request time. See docs/adr/0002-native-crd-controller.md for the
-// full rationale.
+// Package v1alpha1 contains the GitSecret API: the project's Kubernetes
+// integration, with ciphertext carried inline in the object instead of
+// pulled from a cloned repo at request time. See
+// docs/security/design-rationale.md for the full rationale and
+// docs/security/threat-model.md for the security model.
 //
 // +kubebuilder:object:generate=true
 // +groupName=git-secret.opscalehub.io

--- a/charts/git-secret-controller/crds/gitsecret.yaml
+++ b/charts/git-secret-controller/crds/gitsecret.yaml
@@ -74,6 +74,11 @@ spec:
                   exactly the object and field it was sealed for, so copying an entry
                   into a different GitSecret (or renaming/moving this one) fails to
                   decrypt rather than silently applying to the wrong place.
+
+                  Bounded to keep a malformed or hostile object from forcing the
+                  controller to decrypt an unbounded amount of data per reconcile; the
+                  resulting Secret is still subject to the apiserver's own ~1MiB cap.
+                maxProperties: 1024
                 type: object
               encryptedKey:
                 description: |-
@@ -89,6 +94,15 @@ spec:
               target:
                 description: Target describes the Secret this object decrypts into.
                 properties:
+                  adopt:
+                    description: |-
+                      Adopt lets the controller take over a Secret that already exists and
+                      is not owned by this GitSecret, replacing its contents and attaching
+                      an owner reference (so it is deleted with the GitSecret). Off by
+                      default: a name collision with an independently-managed Secret is
+                      reported as a "TargetConflict" Ready=False condition and the existing
+                      Secret is left untouched, rather than being silently clobbered.
+                    type: boolean
                   name:
                     description: |-
                       Name of the Secret to create/update. Defaults to the GitSecret's own

--- a/cmd/git-secret-controller/main.go
+++ b/cmd/git-secret-controller/main.go
@@ -2,8 +2,9 @@
 // GitSecret CRD (api/v1alpha1): it decrypts GitSecret objects into plain
 // Secrets using its own GPG private key, imported at startup exactly the
 // way cmd/git-secret-server imports its repo-decryption key. See
-// internal/controller for the reconcile logic and docs/adr/0002 for why
-// this exists alongside (not instead of, yet) the ESO webhook bridge.
+// internal/controller for the reconcile logic and
+// docs/security/design-rationale.md for why the CRD/controller is the
+// project's Kubernetes integration.
 package main
 
 import (

--- a/cmd/git-secret-seal/main.go
+++ b/cmd/git-secret-seal/main.go
@@ -53,7 +53,7 @@ Usage:
                                 every current human + controller recipient
                                 here, not just the controller's own key, is
                                 what avoids sealed-secrets' single-keypair
-                                DR weakness -- see docs/adr/0002.
+                                DR weakness -- see docs/security/design-rationale.md.
   --target-name NAME             Name of the Secret the controller creates.
                                 Defaults to --name.
   --target-type TYPE             Kubernetes Secret type. Defaults to Opaque.

--- a/config/crd/bases/git-secret.opscalehub.io_gitsecrets.yaml
+++ b/config/crd/bases/git-secret.opscalehub.io_gitsecrets.yaml
@@ -74,6 +74,11 @@ spec:
                   exactly the object and field it was sealed for, so copying an entry
                   into a different GitSecret (or renaming/moving this one) fails to
                   decrypt rather than silently applying to the wrong place.
+
+                  Bounded to keep a malformed or hostile object from forcing the
+                  controller to decrypt an unbounded amount of data per reconcile; the
+                  resulting Secret is still subject to the apiserver's own ~1MiB cap.
+                maxProperties: 1024
                 type: object
               encryptedKey:
                 description: |-
@@ -89,6 +94,15 @@ spec:
               target:
                 description: Target describes the Secret this object decrypts into.
                 properties:
+                  adopt:
+                    description: |-
+                      Adopt lets the controller take over a Secret that already exists and
+                      is not owned by this GitSecret, replacing its contents and attaching
+                      an owner reference (so it is deleted with the GitSecret). Off by
+                      default: a name collision with an independently-managed Secret is
+                      reported as a "TargetConflict" Ready=False condition and the existing
+                      Secret is left untouched, rather than being silently clobbered.
+                    type: boolean
                   name:
                     description: |-
                       Name of the Secret to create/update. Defaults to the GitSecret's own

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -1,0 +1,108 @@
+# Architecture overview
+
+Diagrams for the `GitSecret` CRD + controller path. Companion to
+[design-rationale.md](../security/design-rationale.md) (why) and
+[threat-model.md](../security/threat-model.md) (what's defended).
+
+## End-to-end: seal → apply → reconcile
+
+```
+ ┌─────────────────────┐        ┌──────────────────────────────────────────────┐
+ │  operator workstation│        │                Git repository                │
+ │                      │        │                (ciphertext only)             │
+ │  plaintext value     │        │                                              │
+ │        │             │        │   gitsecret.yaml:                            │
+ │        ▼             │  git   │     spec.encryptedKey:  <GPG-wrapped CEK>     │
+ │  git-secret-seal ────┼──push─▶│     spec.encryptedData: {k: <AEAD envelope>} │
+ │   --recipient <ctrl> │        │                                              │
+ │   --recipient <you>  │        └───────────────────────┬──────────────────────┘
+ │   --recipient <rec>  │                                │ apply path
+ │                      │                                │ (ArgoCD / kubectl)
+ │  local gpg keyring   │                                ▼
+ └─────────────────────┘        ┌──────────────────────────────────────────────┐
+                                │                 kube-apiserver               │
+                                │              GitSecret object in etcd        │
+                                └───────────────────────┬──────────────────────┘
+                                                        │ watch
+                                                        ▼
+                                ┌──────────────────────────────────────────────┐
+                                │            git-secret-controller             │
+                                │                                              │
+                                │  ephemeral GNUPGHOME  ── holds ONLY its own   │
+                                │        │                   private key       │
+                                │        ▼                                     │
+                                │  unwrap encryptedKey ──▶ content key (CEK)    │
+                                │        │                                     │
+                                │        ▼                                     │
+                                │  AEAD-open each encryptedData value           │
+                                │  (AAD = "<ns>/<name>/<key>")                  │
+                                │        │                                     │
+                                │        ▼                                     │
+                                │  CreateOrUpdate Secret/<target>  (owned)      │
+                                └───────────────────────┬──────────────────────┘
+                                                        ▼
+                                                 Secret ──▶ workload
+```
+
+No repo clone, no SSH, no outbound network call on the decrypt path — the
+ciphertext arrives as part of the object via the same apply path as every other
+manifest.
+
+## Envelope: two layers
+
+```
+  spec.encryptedData["API_KEY"]                spec.encryptedKey
+  ┌───────────────────────────┐                ┌───────────────────────────┐
+  │ base64(                   │                │ ASCII-armored GPG message │
+  │   crypto.Seal envelope:   │   sealed with  │   content key (32 bytes)  │
+  │     XChaCha20-Poly1305    │◀──── CEK ──────│   wrapped to N recipients │
+  │     AAD = ns/name/key     │                │                           │
+  │ )                         │                └───────────────────────────┘
+  └───────────────────────────┘                        │
+        one per target key                   unwrappable by ANY one of:
+                                             ├─ controller's key
+                                             ├─ human operator's key
+                                             └─ offline recovery key
+```
+
+Adding/removing a recipient (`git-secret-seal --rewrap`) re-encrypts **only the
+right-hand box**. Every `encryptedData` value is untouched — that is what makes
+recipient changes cheap and key loss recoverable.
+
+## Trust model: why loss ≠ compromise
+
+```
+        recipient key LOST                    recipient key COMPROMISED
+        (holder gone)                         (attacker has it)
+
+  ┌──────────────────────────┐          ┌──────────────────────────────────┐
+  │ any other current        │          │ 1. new content key + RE-SEAL     │
+  │ recipient runs --rewrap  │          │    every encryptedData value     │
+  │ dropping the lost key    │          │ 2. --rewrap to the new key set   │
+  │                          │          │ 3. force-update the object       │
+  │ encryptedData untouched  │          │ 4. OLD object versions in git    │
+  │ → cheap, no re-seal      │          │    history stay wrapped to the   │
+  │                          │          │    compromised key → historical  │
+  │                          │          │    exposure is PERMANENT for     │
+  │                          │          │    anything ever committed       │
+  └──────────────────────────┘          └──────────────────────────────────┘
+```
+
+Multi-recipient GPG buys redundancy against **loss**. It does not by itself
+protect against **compromise** — see threat-model.md T3/T4 and #39.
+
+## Recovery: cluster is disposable
+
+```
+   Git repo (encrypted)  ─────────────┬──────────────┬─────────────────┐
+          + one authorized            │              │                 │
+            recipient private key     ▼              ▼                 ▼
+                                 new cluster A   new cluster B    operator laptop
+                                 new controller  new controller   git-secret-seal
+                                      │               │           --rewrap / decrypt
+                                      ▼               ▼
+                                 identical Secrets reconciled back
+```
+
+The durable artifact is the repo + a key, never the cluster or the controller.
+Losing everything Kubernetes-side is a redeploy, not a data-loss event.

--- a/docs/security/design-rationale.md
+++ b/docs/security/design-rationale.md
@@ -1,0 +1,120 @@
+# Design rationale & history
+
+Why `git-secret` looks the way it does. This is a record of decisions, not a
+roadmap. It replaces the `docs/adr/` set (ADR-0000/0001/0002), which was removed
+once the `GitSecret` CRD became the single Kubernetes story; the reasoning in
+those ADRs is preserved here because it is still the reason the architecture has
+the shape it has.
+
+## The one-sentence thesis
+
+`git-secret` makes it safe to commit a secret to a Git repository: **ciphertext
+is the durable source of truth in Git, and decryption is multi-recipient,
+recoverable, and Kubernetes-native — without any single cluster, controller, or
+key becoming a single point of catastrophic recovery failure.**
+
+Everything below is in service of that sentence.
+
+## How the Kubernetes integration evolved
+
+The CLI + Git-hook workflow (encrypt on `pre-commit`, decrypt on
+`post-checkout`/`post-merge`, block plaintext on `pre-push`) was the whole
+project at first. Secrets were decrypted by hand (`make deploy-secrets`) or via a
+documented-but-fragile ArgoCD Config Management Plugin. Making live secret
+delivery to Kubernetes safe drove four successive designs:
+
+### 1. ArgoCD CMP plugin — set aside
+
+Worked, but routed decrypted plaintext through ArgoCD's own
+manifest-generation/caching pipeline on every sync — a risk ArgoCD's own docs
+call out. `selfHeal` also fights any out-of-band correction of a live `Secret`,
+because ArgoCD's diff only sees "did the plugin's output change," not "is the
+live value still correct."
+
+### 2. Third-party secret store (Vault / Infisical / cloud) behind ESO — rejected
+
+A new external dependency to stand up, secure, and operate. For an
+Iran-hosted production target there is also a lived precedent for geo-blocking
+breaking a dependency (`registry.k8s.io`), which for *live secret reconciliation*
+is a worse outage than a blocked image pull. GitHub's own Secrets feature was
+also considered and is structurally impossible as a backend — its API is
+write-only by design, no credential can read a value back.
+
+### 3. ESO webhook bridge (`git-secret-server`) — built, deployed, then superseded
+
+A small stateless HTTP service behind [ESO's generic Webhook
+provider](https://external-secrets.io/latest/provider/webhook/): clone the repo
+fresh per request, decrypt in memory, return JSON. Bearer-token auth (constant
+time, fails closed), bounded clone concurrency, a dedicated GPG identity separate
+from the Git transport credential.
+
+This validated several things worth keeping:
+
+- Git can stay ciphertext-only; the repo credential and the decryption key are
+  different things with different blast radii.
+- Decryption is the only genuinely novel capability — secret *lifecycle*
+  management is not worth owning.
+- A long-lived network-reachable process holding a live decryption key is a real,
+  reviewable attack surface (this is what the 25 closed findings in #1–#25 were
+  about).
+
+It also surfaced the problem that motivated the next design. ESO's provider model
+assumes a remote store you *query*. `git-secret`'s data is ciphertext — it does
+not need a store; it can be delivered as inert YAML by whatever already applies
+manifests. Forcing it through ESO's Webhook provider meant: a full repo clone in
+the cluster on every refresh interval for every consumer, an SSH transport and
+known-hosts trust decision per clone (the security review confirmed a real
+TOFU/`accept-new` gap with no fail-fast guard), and a five-layer delivery path
+(ArgoCD → ESO CRDs → webhook → clone → decrypt) where several ordering / size /
+retry-exhaustion failures showed up during the production rollout.
+
+`git-secret-server` and its Helm chart still exist and still build. It is no
+longer the recommended integration and receives no new feature work.
+
+### 4. Native `GitSecret` CRD + controller — current
+
+Bitnami `sealed-secrets`' shape — **ciphertext inline in a CRD object, delivered
+by the normal manifest-apply path, decrypted by a controller holding a matching
+private key** — applied to `git-secret`'s existing GPG-backed multi-recipient
+cryptography instead of copying `sealed-secrets`' single-keypair design.
+
+- `spec.encryptedKey` is the GPG-wrapped content key (same mechanism as the
+  `gpg` file backend). `spec.encryptedData` holds one AEAD envelope per target
+  key (same `crypto.Seal`/`crypto.Open` format as whole-file encryption).
+- Reconciling a `GitSecret` makes **no network call**, clones nothing, and needs
+  no SSH transport — the entire SSH-TOFU finding class does not exist on this
+  path, structurally.
+- **Multi-recipient from the start.** `spec.encryptedKey` can be wrapped to any
+  number of recipients — the controller, plus independently any number of humans
+  or offline backup identities. `internal/sealer.Rewrap` re-encrypts *only*
+  `encryptedKey`, leaving every `encryptedData` value byte-for-byte untouched. A
+  lost controller key is a `--rewrap` away from recovery via any other current
+  recipient — not a permanent loss. This is the specific `sealed-secrets`
+  weakness being designed out.
+- `namespace/name/key` is bound into each value's AEAD additional-authenticated-
+  data, so an entry copied into a different `GitSecret` (or a renamed one) fails
+  authentication rather than decrypting where it was not sealed for.
+- Built on `controller-runtime` (same as ESO, cert-manager, `sealed-secrets`) —
+  the informer/reconcile/leader-election machinery is not worth hand-rolling.
+- `git-secret-seal` is the `kubeseal` equivalent: produces a manifest from
+  `--from-literal` / `--from-env-file` / an existing Secret, and rewraps an
+  existing one's recipient list with `--rewrap`.
+
+## What is deliberately foreclosed
+
+Do not re-litigate these without genuinely new information:
+
+- **GitHub Secrets as a backend** — structurally impossible (write-only API).
+- **A third-party secret store as a *required* dependency** — an avoidable new
+  operational and availability dependency. Nothing stops a future design adding
+  one as an *optional* backend.
+- **A decrypt endpoint on the controller** — conflates the seal and decrypt trust
+  domains the CRD design keeps apart. (A *sealing*-only console is a different,
+  narrower question — see the backlog.)
+
+## What this project is not
+
+Not Vault. Not a hosted secret manager. Not a password manager. Not a replacement
+for GPG. Not an identity provider. Not coupled to ESO, ArgoCD, or any one Git
+host. Still fully useful with no Kubernetes at all — the CLI + `gpg` backend is
+the whole product for a team that just wants secrets in Git.

--- a/docs/security/disaster-recovery.md
+++ b/docs/security/disaster-recovery.md
@@ -1,0 +1,156 @@
+# Disaster recovery
+
+The reason this project exists: **the encrypted Git repository plus any one
+authorized recipient private key is enough to recover every secret.** No
+Kubernetes cluster, controller, or single key is a single point of catastrophic
+failure.
+
+This document is the operator runbook for each failure mode. Every scenario has a
+matching test in [`internal/sealer/recovery_test.go`](../../internal/sealer/recovery_test.go)
+— the guarantees are cryptographic, not operational, so they are proven without a
+cluster.
+
+See also: [architecture/overview.md](../architecture/overview.md) (the "loss vs
+compromise" and "cluster is disposable" diagrams) and
+[threat-model.md](threat-model.md) T1–T4.
+
+## Prerequisites for recovery to be possible
+
+These are not optional. Set them up on day one, not after an incident:
+
+1. **Every production `GitSecret` is wrapped to at least one offline recovery
+   recipient** — a GPG key held outside any cluster and outside any single
+   operator's daily-use keyring (e.g. on a hardware token in a safe). This is
+   invariant #1.
+2. **The controller's private key is backed up** somewhere independent of the
+   cluster it runs in (sealed backup, secret manager, offline media).
+3. **The Git repository is mirrored** — the ciphertext is the durable artifact;
+   if it only exists on one host, that host is a single point of failure (T-repo).
+4. **`git-secret-seal` and `gpg` are available** to whoever holds a recovery key.
+
+## Scenario table
+
+| # | Failure | Recoverable? | Runbook |
+|---|---|---|---|
+| A | Controller pod / Deployment destroyed | Yes, automatic | [§A](#a--controller-destroyed) |
+| B | Entire Kubernetes cluster lost | Yes | [§B](#b--whole-cluster-lost) |
+| C | Controller private key lost (no backup) | Yes, if any other recipient survives | [§C](#c--controller-key-lost) |
+| D | An operator leaves | Yes | [§D](#d--operator-leaves) |
+| E | A recipient private key **compromised** | Partially — see the limit | [§E](#e--recipient-key-compromised) |
+| F | `GitSecret` rolled back / rewritten in Git | Yes (re-apply correct revision) | [§F](#f--object-rolled-back-in-git) |
+| G | Git repository itself lost | Only from a mirror / backup | [§G](#g--repository-lost) |
+
+---
+
+## A — controller destroyed
+
+**Nothing to do.** The `GitSecret` objects are in etcd (and Git); the target
+`Secret`s are owned by them. Redeploy `git-secret-controller` with the same GPG
+identity (same `GPG_PRIVATE_KEY_FILE` secret) and it reconciles everything back on
+first pass.
+
+If the target `Secret`s were also lost (etcd damage), the controller recreates
+them from the `GitSecret`s — no data is only in the `Secret`.
+
+## B — whole cluster lost
+
+1. Stand up a new cluster.
+2. Install the CRD (`config/crd/bases/git-secret.opscalehub.io_gitsecrets.yaml`).
+3. Restore the controller's GPG identity `Secret` from backup (prereq #2), or —
+   if that backup is also gone — generate a new controller identity and follow
+   §C to rewrap.
+4. Deploy `git-secret-controller`.
+5. Re-apply the `GitSecret` manifests (ArgoCD pointed at the same repo does this
+   for you).
+6. The controller reconciles identical `Secret`s.
+
+Proven by `TestRecovery_ClusterRebuild_SameKeyReproducesData`.
+
+## C — controller key lost
+
+The controller identity is unrecoverable and there is no backup. As long as **any
+other recipient** (a human operator, or the offline recovery key) can still
+decrypt:
+
+1. Generate a fresh controller identity:
+   ```
+   gpg --batch --passphrase '' --quick-generate-key 'git-secret-controller <ops@example.com>' default default never
+   gpg --armor --export-secret-keys <new-fpr> > controller-key.asc
+   ```
+2. On a machine holding a surviving recipient's private key, and with the new
+   controller's **public** key imported, rewrap every affected object:
+   ```
+   git-secret-seal --rewrap gitsecret.yaml \
+     --recipient <new-controller-fpr> \
+     --recipient <human-fpr> \
+     --recipient <recovery-fpr>
+   ```
+   `--rewrap` replaces `spec.encryptedKey` only — no value is re-encrypted.
+3. Commit the rewrapped manifests; load `controller-key.asc` into the cluster as
+   the controller's `Secret`; deploy.
+
+Proven by `TestRecovery_ControllerKeyLost_HumanRewrapsToNewController`.
+
+## D — operator leaves
+
+Rewrap every object they were a recipient of, dropping their fingerprint:
+
+```
+git-secret-seal --rewrap gitsecret.yaml \
+  --recipient <controller-fpr> --recipient <remaining-human-fpr> --recipient <recovery-fpr>
+```
+
+They can no longer decrypt any **future** version of the object. They **can**
+still decrypt any version already in Git history that was wrapped to them — if
+that matters, treat it as §E (compromise) instead.
+
+Proven by `TestRecovery_OperatorLeaves_RewrapRevokesFutureAccess`.
+
+## E — recipient key compromised
+
+**The limit of the design, stated plainly:** multi-recipient GPG protects against
+*loss* of a key, not *compromise*. A `--rewrap` stops the compromised key from
+opening future object versions, but every prior version of that object lives in
+Git history wrapped to the compromised key, and re-wrapping cannot reach into
+history. Anything ever committed to that object must be considered exposed.
+
+Response:
+
+1. **Rotate the secret values themselves** at their source (new DB password, new
+   API token, …). This is the only step that actually restores confidentiality
+   for data already in history.
+2. Re-seal under a fresh content key (a normal `git-secret-seal` run, not
+   `--rewrap`), dropping the compromised recipient:
+   ```
+   git-secret-seal --namespace prod --name app-secrets \
+     --recipient <controller-fpr> --recipient <human-fpr> --recipient <recovery-fpr> \
+     --from-literal DB_PASSWORD=<new-value> ... > gitsecret.yaml
+   ```
+3. Commit and let it reconcile.
+4. Revoke the compromised GPG key (`gpg --gen-revoke`) and distribute the
+   revocation.
+
+Proven by `TestRecovery_KeyCompromise_RewrapAloneIsInsufficient`, which asserts
+both halves: the compromised key cannot open the rewrapped/re-sealed object, and
+it *can* still open the pre-rewrap object (historical exposure is real).
+
+## F — object rolled back in Git
+
+A force-push or bad revert can make the apply path deliver an old `GitSecret`.
+The controller will faithfully reconcile whatever it is given — it has no notion
+of "newer". Recovery: restore the correct revision in Git and re-apply. Surfacing
+which Git revision produced a given `Secret` is future work (threat-model.md T10).
+
+## G — repository lost
+
+The ciphertext is the durable artifact. Recover the repo from a mirror or backup
+(prereq #3), then proceed as normal. If no copy of the repo exists anywhere, the
+secrets are gone — there is no key that helps, because there is no ciphertext to
+apply it to. **This is why prereq #3 is not optional.**
+
+---
+
+## One-liner for the README
+
+> Losing the Kubernetes cluster does not mean losing the secrets, as long as the
+> Git repository and one authorized recipient private key survive.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -1,0 +1,136 @@
+# Threat model
+
+Status: **initial draft** (tracking issue #38). Covers the two shipped shapes:
+
+1. **CLI + Git hooks** — `git-secret` encrypting files in a repo, `file` / `env` /
+   `gpg` key backends.
+2. **`GitSecret` CRD + `git-secret-controller`** — inline ciphertext reconciled
+   into a Kubernetes `Secret`.
+
+The legacy ESO webhook bridge (`git-secret-server`) is in maintenance and is not
+re-analysed here; its review is issues #1–#25.
+
+This document states what is defended, against whom, and the invariants the code
+must preserve. It is reviewed before any new network-facing surface is added.
+
+---
+
+## 1. Assets
+
+| Asset | Where it lives | Sensitivity |
+|---|---|---|
+| Plaintext secret values | Operator workstation (working tree), controller memory during reconcile, target `Secret` | **Critical** |
+| Encrypted repo + full Git history | Git host, every clone | Confidential (durable source of truth) |
+| Content-encryption keys (per file / per `GitSecret`) | Only ever in memory, wrapped at rest in `key.gpg` / `spec.encryptedKey` | **Critical** |
+| Recipient **private** keys (human) | Operator GPG keyrings, offline backups | **Critical** |
+| Recipient **private** key (controller) | One Kubernetes `Secret`, imported into an ephemeral `GNUPGHOME` at startup | **Critical** |
+| Recipient **public** keys | Local keyrings today; a discoverable keyring is proposed (#47) | Public |
+| `GitSecret` objects | etcd, Git (as manifests), every apply path | Confidential |
+| Target `Secret` objects | etcd, mounted into workloads | **Critical** |
+| Controller ServiceAccount token / RBAC | Cluster | High |
+| Git transport credential (deploy key) | Whatever clones the repo | Medium (guards ciphertext only) |
+| Controller logs / Events / `status` / metrics | Cluster, log sinks | Must contain **no** plaintext or key material |
+| `.repo-enc.yml` | Git (committed) | Integrity-sensitive (defines encryption policy) |
+
+---
+
+## 2. Trust boundaries
+
+```
+ operator workstation ── git push ──▶ Git host ── apply path (ArgoCD/kubectl) ──▶ kube-apiserver
+        │                               │                                              │
+   local gpg keyring              (ciphertext only)                            git-secret-controller
+        │                                                                             │
+   git-secret / git-secret-seal                                            ephemeral GNUPGHOME + its key
+                                                                                      │
+                                                                              target Secret ──▶ workload
+```
+
+- **Git host is untrusted for confidentiality**, trusted for availability/integrity
+  only to the extent commit history is (see threat T10). It only ever holds
+  ciphertext.
+- **The apply path (ArgoCD, `kubectl`) is trusted for integrity** — it decides
+  which `GitSecret` objects reach the cluster. It never sees plaintext.
+- **The controller is trusted with its own key only.** It can decrypt exactly the
+  `GitSecret`s whose `encryptedKey` is wrapped to its identity, and nothing else.
+- **The operator workstation + local GPG keyring is the root of trust** for the
+  CLI workflow. Compromise there is game over for anything that workstation can
+  decrypt (T6).
+- **etcd / the apiserver is trusted.** A cluster admin who can read `Secret`s
+  needs no help from `git-secret` (T8) — this project does not defend against a
+  malicious cluster administrator, and does not claim to.
+
+---
+
+## 3. Threats
+
+Notation: **L** = availability/recovery, **C** = confidentiality, **I** = integrity.
+
+| # | Threat | Class | Current posture |
+|---|---|---|---|
+| T1 | Controller pod / Deployment destroyed | L | **Handled.** State is in Git + the controller `Secret`; a fresh controller reconciles everything back. |
+| T2 | Entire cluster lost | L | **Handled by design, not yet tested (#39).** Re-apply `GitSecret`s to a new cluster + restore the controller key → identical `Secret`s. |
+| T3 | One recipient **private key lost** (holder unavailable) | L | **Handled.** Any other current recipient runs `git-secret-seal --rewrap` to drop it / add a replacement — `encryptedData` is never re-sealed. |
+| T4 | One recipient **private key compromised** | C | **Partial.** `--rewrap` stops *future* ciphertext exposure, but every historical version of the object in Git stays wrapped to the compromised key → permanent historical exposure. Requires a new content key + full re-seal. Documented in #39; not automated. |
+| T5 | Malicious / oversized `GitSecret` applied | I / L (DoS) | **Gap (#42).** No bound on `encryptedData` size/count; a huge object makes the controller decrypt it all per reconcile. |
+| T6 | Operator workstation compromised | C | **Out of scope to prevent.** Blast radius = everything that workstation's keyring can decrypt. Mitigation is operational: per-person keys, hardware-backed keys, offline recovery key not on any workstation. |
+| T7 | Plaintext leak via logs / Events / `status` / metrics | C | **Invariant (I3). Mostly held**; needs a regression test asserting decrypt-error strings never echo plaintext (#42 item 3). |
+| T8 | Malicious cluster administrator | C | **Out of scope.** Anyone who can `kubectl get secret -o yaml` wins without touching `git-secret`. |
+| T9 | Compromised controller pod | C | Blast radius = `GitSecret`s wrapped to the controller key. Mitigation: don't wrap every object to every controller (per-cluster/per-env recipients, #43); `runAsNonRoot`, read-only rootfs, minimal RBAC. |
+| T10 | Rollback / history-rewrite of a `GitSecret` in Git | I | An old object version re-applied re-installs old secret values silently. Provenance (which Git revision produced this Secret) is not surfaced — future work. |
+| T11 | Recipient substitution — object sealed to an attacker key alongside the real ones | C | **Gap (#40).** Recipients are not visible on the object; a reviewer cannot see who an object is sealed to without inspecting the armored blob (which carries key IDs, not fingerprints). |
+| T12 | Pre-existing target `Secret` silently adopted & cleared | I | **Gap (#42).** An ownerless `Secret` with a colliding name is adopted, its data replaced, and it is deleted when the `GitSecret` is. |
+| T13 | Plaintext committed to Git (CLI path) | C | **Handled.** `verify` + the `pre-push` hook fail closed; `SECRETIZE_SKIP_HOOKS` is opt-in per-invocation, never tied to ambient `CI`. |
+| T14 | Recipient specified as a short key ID / email, resolving to the wrong key | C | **Handled.** `gpgutil.ValidFingerprint` requires a full 40/64-hex fingerprint everywhere recipients are accepted. |
+
+---
+
+## 4. Security invariants
+
+Implementations must preserve these. A change that breaks one is a security
+regression regardless of the feature it enables.
+
+1. **The controller is never the only holder of a key that can open production
+   data.** Every production `GitSecret` is wrapped to at least one offline
+   recovery recipient in addition to the controller.
+2. **Losing Kubernetes does not lose the secrets.** The encrypted repo + any one
+   authorized recipient private key is sufficient for full recovery.
+3. **Plaintext never appears in logs, Kubernetes Events, `status`, or metrics** —
+   neither secret values nor unwrapped content keys nor private key bytes.
+4. **Recipient identity is a full GPG fingerprint**, never a display name, email,
+   or short key ID. (`gpgutil.ValidFingerprint`.)
+5. **A `GitSecret` decrypts only to the exact object/namespace/key its AEAD was
+   bound to.** (`internal/sealer.aad`; `TestUnsealWrongObjectFails`.)
+6. **Adding or removing a recipient never re-encrypts `encryptedData`** — only
+   `encryptedKey` is rewrapped. (`internal/sealer.Rewrap`.)
+7. **The controller decrypts only what its own key can unwrap** — it holds no
+   master key and cannot enumerate or open objects sealed to other identities.
+8. **`git-secret-seal` never writes plaintext to disk** beyond what the caller
+   passed in.
+9. **Recipient changes are reviewable** — visible in the Git diff of the object,
+   not buried in an opaque re-encrypted blob. *(Depends on #40.)*
+10. **The apply path, not any authoring tool, is the authorization boundary** for
+    what reaches the cluster.
+
+---
+
+## 5. Non-goals
+
+- Defending against a malicious kube cluster administrator (T8) or a compromised
+  operator workstation (T6) — both are outside the model; mitigations for them are
+  operational, not cryptographic.
+- Preventing historical ciphertext exposure after a key compromise (T4) — Git
+  history is immutable by design; the answer is rotation + accepting the exposure
+  of anything already committed.
+- Being a general-purpose secret store, an identity provider, or a Vault
+  replacement.
+- Hiding the *existence* or *shape* (key names, recipient count) of a secret —
+  only its values are confidential.
+
+---
+
+## 6. Open items feeding this model
+
+#39 (DR + loss-vs-compromise, tested) · #40 (recipient visibility) · #41
+(recipient lifecycle) · #42 (controller adoption + input bounds + status-leak
+test) · #43 (multi-cluster blast radius) · #47 (keyring / pubkey discovery).

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -72,9 +72,9 @@ Notation: **L** = availability/recovery, **C** = confidentiality, **I** = integr
 | # | Threat | Class | Current posture |
 |---|---|---|---|
 | T1 | Controller pod / Deployment destroyed | L | **Handled.** State is in Git + the controller `Secret`; a fresh controller reconciles everything back. |
-| T2 | Entire cluster lost | L | **Handled by design, not yet tested (#39).** Re-apply `GitSecret`s to a new cluster + restore the controller key → identical `Secret`s. |
-| T3 | One recipient **private key lost** (holder unavailable) | L | **Handled.** Any other current recipient runs `git-secret-seal --rewrap` to drop it / add a replacement — `encryptedData` is never re-sealed. |
-| T4 | One recipient **private key compromised** | C | **Partial.** `--rewrap` stops *future* ciphertext exposure, but every historical version of the object in Git stays wrapped to the compromised key → permanent historical exposure. Requires a new content key + full re-seal. Documented in #39; not automated. |
+| T2 | Entire cluster lost | L | **Handled.** Re-apply `GitSecret`s to a new cluster + restore the controller key → identical `Secret`s. Runbook §B; test `TestRecovery_ClusterRebuild_SameKeyReproducesData`. |
+| T3 | One recipient **private key lost** (holder unavailable) | L | **Handled.** Any other current recipient runs `git-secret-seal --rewrap` to drop it / add a replacement — `encryptedData` is never re-sealed. Runbook §C/§D; tests `TestRecovery_ControllerKeyLost_*`, `TestRecovery_OperatorLeaves_*`. |
+| T4 | One recipient **private key compromised** | C | **Partial, and understood.** `--rewrap` stops *future* exposure, but every historical version of the object in Git stays wrapped to the compromised key → permanent historical exposure. Requires rotating the secret values + a new content key + full re-seal. Runbook §E; test `TestRecovery_KeyCompromise_RewrapAloneIsInsufficient`. |
 | T5 | Malicious / oversized `GitSecret` applied | I / L (DoS) | **Gap (#42).** No bound on `encryptedData` size/count; a huge object makes the controller decrypt it all per reconcile. |
 | T6 | Operator workstation compromised | C | **Out of scope to prevent.** Blast radius = everything that workstation's keyring can decrypt. Mitigation is operational: per-person keys, hardware-backed keys, offline recovery key not on any workstation. |
 | T7 | Plaintext leak via logs / Events / `status` / metrics | C | **Invariant (I3). Mostly held**; needs a regression test asserting decrypt-error strings never echo plaintext (#42 item 3). |

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -75,14 +75,14 @@ Notation: **L** = availability/recovery, **C** = confidentiality, **I** = integr
 | T2 | Entire cluster lost | L | **Handled.** Re-apply `GitSecret`s to a new cluster + restore the controller key → identical `Secret`s. Runbook §B; test `TestRecovery_ClusterRebuild_SameKeyReproducesData`. |
 | T3 | One recipient **private key lost** (holder unavailable) | L | **Handled.** Any other current recipient runs `git-secret-seal --rewrap` to drop it / add a replacement — `encryptedData` is never re-sealed. Runbook §C/§D; tests `TestRecovery_ControllerKeyLost_*`, `TestRecovery_OperatorLeaves_*`. |
 | T4 | One recipient **private key compromised** | C | **Partial, and understood.** `--rewrap` stops *future* exposure, but every historical version of the object in Git stays wrapped to the compromised key → permanent historical exposure. Requires rotating the secret values + a new content key + full re-seal. Runbook §E; test `TestRecovery_KeyCompromise_RewrapAloneIsInsufficient`. |
-| T5 | Malicious / oversized `GitSecret` applied | I / L (DoS) | **Gap (#42).** No bound on `encryptedData` size/count; a huge object makes the controller decrypt it all per reconcile. |
+| T5 | Malicious / oversized `GitSecret` applied | I / L (DoS) | **Handled.** `encryptedData` is capped at 1024 entries (CRD `maxProperties` + `sealer.MaxEntries`) and 1 MiB per encoded value; the resulting `Secret` is separately capped by the apiserver. |
 | T6 | Operator workstation compromised | C | **Out of scope to prevent.** Blast radius = everything that workstation's keyring can decrypt. Mitigation is operational: per-person keys, hardware-backed keys, offline recovery key not on any workstation. |
-| T7 | Plaintext leak via logs / Events / `status` / metrics | C | **Invariant (I3). Mostly held**; needs a regression test asserting decrypt-error strings never echo plaintext (#42 item 3). |
+| T7 | Plaintext leak via logs / Events / `status` / metrics | C | **Invariant (I3), regression-tested.** `TestUnseal_ErrorDoesNotLeakPlaintext` asserts a tampered-envelope failure never echoes the plaintext into the returned error (which the controller copies into `.status`). |
 | T8 | Malicious cluster administrator | C | **Out of scope.** Anyone who can `kubectl get secret -o yaml` wins without touching `git-secret`. |
 | T9 | Compromised controller pod | C | Blast radius = `GitSecret`s wrapped to the controller key. Mitigation: don't wrap every object to every controller (per-cluster/per-env recipients, #43); `runAsNonRoot`, read-only rootfs, minimal RBAC. |
 | T10 | Rollback / history-rewrite of a `GitSecret` in Git | I | An old object version re-applied re-installs old secret values silently. Provenance (which Git revision produced this Secret) is not surfaced — future work. |
 | T11 | Recipient substitution — object sealed to an attacker key alongside the real ones | C | **Gap (#40).** Recipients are not visible on the object; a reviewer cannot see who an object is sealed to without inspecting the armored blob (which carries key IDs, not fingerprints). |
-| T12 | Pre-existing target `Secret` silently adopted & cleared | I | **Gap (#42).** An ownerless `Secret` with a colliding name is adopted, its data replaced, and it is deleted when the `GitSecret` is. |
+| T12 | Pre-existing target `Secret` silently adopted & cleared | I | **Handled.** A colliding `Secret` this `GitSecret` does not own is left untouched and a `TargetConflict` Ready=False condition is set, unless the operator opts in with `spec.target.adopt`. Tests `TestReconcile_DoesNotClobberUnownedSecret` / `_AdoptsUnownedSecretWhenOptedIn`. |
 | T13 | Plaintext committed to Git (CLI path) | C | **Handled.** `verify` + the `pre-push` hook fail closed; `SECRETIZE_SKIP_HOOKS` is opt-in per-invocation, never tied to ambient `CI`. |
 | T14 | Recipient specified as a short key ID / email, resolving to the wrong key | C | **Handled.** `gpgutil.ValidFingerprint` requires a full 40/64-hex fingerprint everywhere recipients are accepted. |
 
@@ -134,6 +134,8 @@ regression regardless of the feature it enables.
 
 ## 6. Open items feeding this model
 
-#39 (DR + loss-vs-compromise, tested) · #40 (recipient visibility) · #41
-(recipient lifecycle) · #42 (controller adoption + input bounds + status-leak
-test) · #43 (multi-cluster blast radius) · #47 (keyring / pubkey discovery).
+#40 (recipient visibility) · #41 (recipient lifecycle) · #43 (multi-cluster blast
+radius) · #47 (keyring / pubkey discovery).
+
+Closed: #38 (this doc) · #39 (DR runbooks + tests) · #42 (controller adoption
+guard, input bounds, status-leak regression test).

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -7,6 +7,9 @@ Status: **initial draft** (tracking issue #38). Covers the two shipped shapes:
 2. **`GitSecret` CRD + `git-secret-controller`** — inline ciphertext reconciled
    into a Kubernetes `Secret`.
 
+See [architecture/overview.md](../architecture/overview.md) for diagrams of the
+flow, the envelope, and the trust/recovery model.
+
 The legacy ESO webhook bridge (`git-secret-server`) is in maintenance and is not
 re-analysed here; its review is issues #1–#25.
 

--- a/internal/controller/gitsecret_controller.go
+++ b/internal/controller/gitsecret_controller.go
@@ -74,6 +74,32 @@ func (r *GitSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, nil
 	}
 
+	// Guard against silently clobbering a Secret this GitSecret does not
+	// own. CreateOrUpdate on its own will happily adopt an ownerless Secret
+	// with a colliding name -- clearing its data, replacing it with this
+	// object's, and attaching an owner reference so it is deleted with the
+	// GitSecret. Only take over such a Secret when the operator has opted in
+	// with spec.target.adopt; otherwise report the collision and leave it
+	// untouched.
+	var existing corev1.Secret
+	getErr := r.Get(ctx, types.NamespacedName{Namespace: gs.Namespace, Name: targetName}, &existing)
+	switch {
+	case getErr == nil:
+		owner := metav1.GetControllerOf(&existing)
+		ownedByThis := owner != nil && owner.Kind == "GitSecret" && owner.Name == gs.Name && owner.UID == gs.UID
+		if !ownedByThis && !gs.Spec.Target.Adopt {
+			msg := fmt.Sprintf("Secret/%s already exists and is not managed by this GitSecret; set spec.target.adopt to take it over", targetName)
+			logger.Info("target Secret conflict", "gitsecret", req.NamespacedName, "secret", targetName)
+			r.setCondition(&gs, metav1.ConditionFalse, "TargetConflict", msg)
+			if statusErr := r.Status().Update(ctx, &gs); statusErr != nil {
+				logger.Error(statusErr, "failed to record TargetConflict status")
+			}
+			return ctrl.Result{}, nil
+		}
+	case !apierrors.IsNotFound(getErr):
+		return ctrl.Result{}, fmt.Errorf("get target Secret: %w", getErr)
+	}
+
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      targetName,
@@ -104,12 +130,11 @@ func (r *GitSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Owning the target Secret (rather than ESO's adopt-in-place
 		// Merge/Retain pattern) is deliberate here: a GitSecret created
 		// fresh is the sole source of truth for its target, so deleting
-		// it should delete the Secret too, same as sealed-secrets. This
-		// is not *meant* to adopt an already-existing, independently
-		// managed Secret -- that should be a separate, explicitly-gated
-		// migration decision per target. NOTE: this is not yet enforced;
-		// an ownerless Secret with a colliding name is currently adopted
-		// (and its data cleared) silently -- tracked in #42.
+		// it should delete the Secret too, same as sealed-secrets.
+		// Taking over a Secret this GitSecret does not already own is
+		// gated on spec.target.adopt and checked above -- by the time
+		// CreateOrUpdate runs here, either the Secret is ours, it does
+		// not exist, or the operator opted in.
 		return controllerutil.SetControllerReference(&gs, secret, r.Client.Scheme())
 	})
 	if err != nil {

--- a/internal/controller/gitsecret_controller.go
+++ b/internal/controller/gitsecret_controller.go
@@ -105,10 +105,11 @@ func (r *GitSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		// Merge/Retain pattern) is deliberate here: a GitSecret created
 		// fresh is the sole source of truth for its target, so deleting
 		// it should delete the Secret too, same as sealed-secrets. This
-		// is NOT used to adopt any already-existing, independently
-		// managed Secret -- see docs/adr/0002 on why that's a separate,
-		// explicitly-gated migration decision per target, not something
-		// this controller does automatically.
+		// is not *meant* to adopt an already-existing, independently
+		// managed Secret -- that should be a separate, explicitly-gated
+		// migration decision per target. NOTE: this is not yet enforced;
+		// an ownerless Secret with a colliding name is currently adopted
+		// (and its data cleared) silently -- tracked in #42.
 		return controllerutil.SetControllerReference(&gs, secret, r.Client.Scheme())
 	})
 	if err != nil {

--- a/internal/controller/gitsecret_controller_test.go
+++ b/internal/controller/gitsecret_controller_test.go
@@ -250,6 +250,121 @@ func TestReconcile_RevertsDriftOnOwnedSecret(t *testing.T) {
 	}
 }
 
+// TestReconcile_DoesNotClobberUnownedSecret: a Secret with the target name
+// already exists and is managed by something else (no owner reference back
+// to this GitSecret). Reconcile must leave it completely untouched and
+// report a TargetConflict condition, not silently clear its data and adopt
+// it.
+func TestReconcile_DoesNotClobberUnownedSecret(t *testing.T) {
+	gnupgHome := shortTempDir(t)
+	fpr := genTestKey(t, gnupgHome)
+	t.Setenv("GNUPGHOME", gnupgHome)
+
+	spec, err := sealer.Seal("downtime", "downtime-secrets", map[string]string{"OURS": "from-gitsecret"}, []string{fpr})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	gs := &gitsecretv1alpha1.GitSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "downtime-secrets", Namespace: "downtime"},
+		Spec:       spec,
+	}
+	preExisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "downtime-secrets", Namespace: "downtime"},
+		Data:       map[string][]byte{"THEIRS": []byte("managed-elsewhere")},
+	}
+
+	scheme := newScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gs, preExisting).
+		WithStatusSubresource(&gitsecretv1alpha1.GitSecret{}).
+		Build()
+
+	r := &GitSecretReconciler{Client: fakeClient}
+	req := ctrl.Request{NamespacedName: namespacedName("downtime", "downtime-secrets")}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var after corev1.Secret
+	if err := fakeClient.Get(context.Background(), namespacedName("downtime", "downtime-secrets"), &after); err != nil {
+		t.Fatal(err)
+	}
+	if string(after.Data["THEIRS"]) != "managed-elsewhere" {
+		t.Errorf("pre-existing Secret data was modified: %#v", after.Data)
+	}
+	if _, ours := after.Data["OURS"]; ours {
+		t.Error("controller wrote its own key into a Secret it does not own")
+	}
+	if _, ours := after.StringData["OURS"]; ours {
+		t.Error("controller wrote its own key (StringData) into a Secret it does not own")
+	}
+	if len(after.OwnerReferences) != 0 {
+		t.Errorf("controller adopted an unowned Secret: %#v", after.OwnerReferences)
+	}
+
+	var updated gitsecretv1alpha1.GitSecret
+	if err := fakeClient.Get(context.Background(), namespacedName("downtime", "downtime-secrets"), &updated); err != nil {
+		t.Fatal(err)
+	}
+	var ready *metav1.Condition
+	for i := range updated.Status.Conditions {
+		if updated.Status.Conditions[i].Type == conditionReady {
+			ready = &updated.Status.Conditions[i]
+		}
+	}
+	if ready == nil || ready.Status != metav1.ConditionFalse || ready.Reason != "TargetConflict" {
+		t.Errorf("Ready condition = %+v, want False/TargetConflict", ready)
+	}
+}
+
+// TestReconcile_AdoptsUnownedSecretWhenOptedIn: same collision, but
+// spec.target.adopt is set, so the controller is expected to take the
+// Secret over.
+func TestReconcile_AdoptsUnownedSecretWhenOptedIn(t *testing.T) {
+	gnupgHome := shortTempDir(t)
+	fpr := genTestKey(t, gnupgHome)
+	t.Setenv("GNUPGHOME", gnupgHome)
+
+	spec, err := sealer.Seal("downtime", "downtime-secrets", map[string]string{"OURS": "from-gitsecret"}, []string{fpr})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	spec.Target.Adopt = true
+	gs := &gitsecretv1alpha1.GitSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "downtime-secrets", Namespace: "downtime"},
+		Spec:       spec,
+	}
+	preExisting := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "downtime-secrets", Namespace: "downtime"},
+		Data:       map[string][]byte{"THEIRS": []byte("managed-elsewhere")},
+	}
+
+	scheme := newScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gs, preExisting).
+		WithStatusSubresource(&gitsecretv1alpha1.GitSecret{}).
+		Build()
+
+	r := &GitSecretReconciler{Client: fakeClient}
+	req := ctrl.Request{NamespacedName: namespacedName("downtime", "downtime-secrets")}
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("Reconcile: %v", err)
+	}
+
+	var after corev1.Secret
+	if err := fakeClient.Get(context.Background(), namespacedName("downtime", "downtime-secrets"), &after); err != nil {
+		t.Fatal(err)
+	}
+	if after.StringData["OURS"] != "from-gitsecret" {
+		t.Errorf("adopted Secret missing our data: %#v", after.StringData)
+	}
+	if len(after.OwnerReferences) != 1 || after.OwnerReferences[0].Kind != "GitSecret" {
+		t.Errorf("adopted Secret not owned by the GitSecret: %#v", after.OwnerReferences)
+	}
+}
+
 func TestReconcile_WrongKeyReportsFailureWithoutCreatingSecret(t *testing.T) {
 	sealingHome := shortTempDir(t)
 	sealFpr := genTestKey(t, sealingHome)

--- a/internal/sealer/recovery_test.go
+++ b/internal/sealer/recovery_test.go
@@ -1,0 +1,206 @@
+package sealer
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// These tests are the executable form of docs/security/disaster-recovery.md:
+// each one corresponds to a scenario row in that document and proves (or, for
+// the compromise case, deliberately proves the *limit* of) what recovery the
+// cryptography actually gives you. They run entirely on throwaway GPG keys in
+// isolated GNUPGHOMEs -- no cluster required, because every recovery guarantee
+// this project makes is a property of the seal/rewrap envelope, not of
+// Kubernetes.
+
+func exportSecretKey(t *testing.T, gnupgHome, fpr string) []byte {
+	t.Helper()
+	cmd := exec.Command("gpg", "--batch", "--armor", "--export-secret-keys", fpr)
+	cmd.Env = append(os.Environ(), "GNUPGHOME="+gnupgHome)
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("export secret key: %v", err)
+	}
+	return out
+}
+
+func importSecretKey(t *testing.T, gnupgHome string, armored []byte) {
+	t.Helper()
+	cmd := exec.Command("gpg", "--batch", "--import")
+	cmd.Env = append(os.Environ(), "GNUPGHOME="+gnupgHome)
+	cmd.Stdin = strings.NewReader(string(armored))
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("import secret key: %v\n%s", err, out)
+	}
+}
+
+// Scenario A/B -- controller pod, or the entire cluster, is destroyed.
+// A fresh controller with the same GPG identity, handed the same GitSecret
+// object, reproduces the identical Secret. Modeled here as: export the
+// controller's private key, throw the keyring away, stand up a brand-new
+// keyring, re-import, Unseal.
+func TestRecovery_ClusterRebuild_SameKeyReproducesData(t *testing.T) {
+	oldHome := shortTempDir(t)
+	fpr := genTestKey(t, oldHome)
+	t.Setenv("GNUPGHOME", oldHome)
+
+	data := map[string]string{"API_KEY": "s3cr3t", "DB_URL": "postgres://x"}
+	spec, err := Seal("prod", "app-secrets", data, []string{fpr})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	// The old cluster (and its keyring) is gone. Only two things survived:
+	// the GitSecret manifest (spec) and a backup of the controller key.
+	keyBackup := exportSecretKey(t, oldHome, fpr)
+	os.RemoveAll(oldHome)
+
+	newHome := shortTempDir(t)
+	importSecretKey(t, newHome, keyBackup)
+	t.Setenv("GNUPGHOME", newHome)
+
+	got, err := Unseal("prod", "app-secrets", spec)
+	if err != nil {
+		t.Fatalf("fresh controller could not Unseal after rebuild: %v", err)
+	}
+	for k, want := range data {
+		if got[k] != want {
+			t.Errorf("key %q: got %q, want %q", k, got[k], want)
+		}
+	}
+}
+
+// Scenario C -- the controller's private key is lost (no backup, holder gone),
+// but the GitSecret was also wrapped to a human operator. That operator
+// rewraps to a fresh controller identity. No value is re-sealed; the new
+// controller decrypts independently.
+func TestRecovery_ControllerKeyLost_HumanRewrapsToNewController(t *testing.T) {
+	humanHome := shortTempDir(t)
+	humanFpr := genTestKey(t, humanHome)
+
+	oldCtrlHome := shortTempDir(t)
+	oldCtrlFpr := genTestKey(t, oldCtrlHome)
+
+	// Seal (done by the human) needs both public keys present.
+	importPublicKey(t, humanHome, exportPublicKey(t, oldCtrlHome, oldCtrlFpr))
+	t.Setenv("GNUPGHOME", humanHome)
+	spec, err := Seal("prod", "app-secrets", map[string]string{"K": "v"}, []string{humanFpr, oldCtrlFpr})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	originalData := spec.EncryptedData["K"]
+
+	// The controller key is now unrecoverable. A new controller identity is
+	// generated; the human (still a current recipient) rewraps to it.
+	newCtrlHome := shortTempDir(t)
+	newCtrlFpr := genTestKey(t, newCtrlHome)
+	importPublicKey(t, humanHome, exportPublicKey(t, newCtrlHome, newCtrlFpr))
+
+	t.Setenv("GNUPGHOME", humanHome)
+	rewrapped, err := Rewrap(spec, []string{humanFpr, newCtrlFpr})
+	if err != nil {
+		t.Fatalf("Rewrap: %v", err)
+	}
+	if rewrapped.EncryptedData["K"] != originalData {
+		t.Fatal("Rewrap re-sealed a value; recovery must never touch encryptedData")
+	}
+
+	// The new controller, which never saw the original Seal, decrypts.
+	t.Setenv("GNUPGHOME", newCtrlHome)
+	got, err := Unseal("prod", "app-secrets", rewrapped)
+	if err != nil || got["K"] != "v" {
+		t.Fatalf("new controller cannot decrypt after rewrap: got=%v err=%v", got, err)
+	}
+}
+
+// Scenario D -- an operator leaves. Rewrapping without their fingerprint means
+// they cannot decrypt any *future* version of the object. (They can still read
+// whatever they already pulled from git history -- that is the compromise
+// case, scenario E, not this one.)
+func TestRecovery_OperatorLeaves_RewrapRevokesFutureAccess(t *testing.T) {
+	aliceHome := shortTempDir(t)
+	aliceFpr := genTestKey(t, aliceHome)
+	bobHome := shortTempDir(t)
+	bobFpr := genTestKey(t, bobHome)
+
+	importPublicKey(t, aliceHome, exportPublicKey(t, bobHome, bobFpr))
+	t.Setenv("GNUPGHOME", aliceHome)
+	spec, err := Seal("prod", "app-secrets", map[string]string{"K": "v"}, []string{aliceFpr, bobFpr})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	// Bob rewraps, dropping Alice.
+	t.Setenv("GNUPGHOME", bobHome)
+	rewrapped, err := Rewrap(spec, []string{bobFpr})
+	if err != nil {
+		t.Fatalf("Rewrap: %v", err)
+	}
+
+	// Bob still works.
+	if got, err := Unseal("prod", "app-secrets", rewrapped); err != nil || got["K"] != "v" {
+		t.Fatalf("Bob lost access after his own rewrap: got=%v err=%v", got, err)
+	}
+
+	// Alice cannot open the rewrapped object.
+	t.Setenv("GNUPGHOME", aliceHome)
+	if _, err := Unseal("prod", "app-secrets", rewrapped); err == nil {
+		t.Fatal("Alice could still decrypt after being dropped from the recipient list")
+	}
+}
+
+// Scenario E -- a recipient key is COMPROMISED. This test documents the limit
+// of the design: rewrap alone is NOT sufficient, because the pre-rewrap object
+// (which lives forever in git history) stays readable by the compromised key.
+// Only a fresh content key + full re-seal produces an object the compromised
+// key cannot open.
+func TestRecovery_KeyCompromise_RewrapAloneIsInsufficient(t *testing.T) {
+	ownerHome := shortTempDir(t)
+	ownerFpr := genTestKey(t, ownerHome)
+	attackerHome := shortTempDir(t)
+	attackerFpr := genTestKey(t, attackerHome)
+
+	// The attacker's key was a legitimate recipient before the compromise
+	// was discovered.
+	importPublicKey(t, ownerHome, exportPublicKey(t, attackerHome, attackerFpr))
+	t.Setenv("GNUPGHOME", ownerHome)
+	original, err := Seal("prod", "app-secrets", map[string]string{"K": "v"}, []string{ownerFpr, attackerFpr})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	// Response step 1: rewrap to drop the attacker.
+	rewrapped, err := Rewrap(original, []string{ownerFpr})
+	if err != nil {
+		t.Fatalf("Rewrap: %v", err)
+	}
+
+	// The attacker CANNOT open the rewrapped object...
+	t.Setenv("GNUPGHOME", attackerHome)
+	if _, err := Unseal("prod", "app-secrets", rewrapped); err == nil {
+		t.Fatal("attacker opened the rewrapped object; expected failure")
+	}
+	// ...but they CAN still open the original, which is what git history holds.
+	// This is the property operators must understand, so assert it explicitly.
+	if got, err := Unseal("prod", "app-secrets", original); err != nil || got["K"] != "v" {
+		t.Fatalf("expected the compromised key to still open the pre-rewrap object "+
+			"(historical exposure is real): got=%v err=%v", got, err)
+	}
+
+	// Response step 2: full re-seal under a fresh content key. Only now is
+	// there an object version the compromised key has never been able to open.
+	t.Setenv("GNUPGHOME", ownerHome)
+	resealed, err := Seal("prod", "app-secrets", map[string]string{"K": "v"}, []string{ownerFpr})
+	if err != nil {
+		t.Fatalf("re-Seal: %v", err)
+	}
+	if resealed.EncryptedData["K"] == original.EncryptedData["K"] {
+		t.Fatal("re-Seal produced identical ciphertext; the content key was not rotated")
+	}
+	t.Setenv("GNUPGHOME", attackerHome)
+	if _, err := Unseal("prod", "app-secrets", resealed); err == nil {
+		t.Fatal("attacker opened the re-sealed object; content-key rotation did not take effect")
+	}
+}

--- a/internal/sealer/recovery_test.go
+++ b/internal/sealer/recovery_test.go
@@ -1,6 +1,8 @@
 package sealer
 
 import (
+	"encoding/base64"
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -202,5 +204,52 @@ func TestRecovery_KeyCompromise_RewrapAloneIsInsufficient(t *testing.T) {
 	t.Setenv("GNUPGHOME", attackerHome)
 	if _, err := Unseal("prod", "app-secrets", resealed); err == nil {
 		t.Fatal("attacker opened the re-sealed object; content-key rotation did not take effect")
+	}
+}
+
+// The "no plaintext in error output" invariant (threat-model.md I3): a
+// corrupted or tampered envelope must fail without the decrypt path ever
+// echoing a secret value into the error it returns (which the controller
+// copies verbatim into GitSecret .status).
+func TestUnseal_ErrorDoesNotLeakPlaintext(t *testing.T) {
+	gnupgHome := shortTempDir(t)
+	fpr := genTestKey(t, gnupgHome)
+	t.Setenv("GNUPGHOME", gnupgHome)
+
+	const secretValue = "correct-horse-battery-staple-unique-marker"
+	spec, err := Seal("prod", "app-secrets", map[string]string{"K": secretValue}, []string{fpr})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	// Flip a byte in the middle of the (decoded) envelope so AEAD auth fails.
+	raw, _ := base64.StdEncoding.DecodeString(spec.EncryptedData["K"])
+	raw[len(raw)/2] ^= 0xff
+	spec.EncryptedData["K"] = base64.StdEncoding.EncodeToString(raw)
+
+	_, err = Unseal("prod", "app-secrets", spec)
+	if err == nil {
+		t.Fatal("Unseal accepted a tampered envelope")
+	}
+	if strings.Contains(err.Error(), secretValue) {
+		t.Fatalf("error message leaked the plaintext value: %v", err)
+	}
+}
+
+func TestUnseal_RejectsTooManyEntries(t *testing.T) {
+	gnupgHome := shortTempDir(t)
+	fpr := genTestKey(t, gnupgHome)
+	t.Setenv("GNUPGHOME", gnupgHome)
+
+	spec, err := Seal("prod", "app-secrets", map[string]string{"K": "v"}, []string{fpr})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	// Pad EncryptedData past the limit with junk entries.
+	for i := 0; i <= MaxEntries; i++ {
+		spec.EncryptedData[fmt.Sprintf("junk-%d", i)] = "junk"
+	}
+	if _, err := Unseal("prod", "app-secrets", spec); err == nil {
+		t.Fatal("Unseal processed an over-limit EncryptedData map")
 	}
 }

--- a/internal/sealer/sealer.go
+++ b/internal/sealer/sealer.go
@@ -21,6 +21,17 @@ import (
 
 const keySize = 32 // chacha20poly1305.KeySize; avoids importing x/crypto here just for the constant.
 
+// Bounds on what Unseal will process from a single object, so a malformed
+// or hostile GitSecret cannot force the controller to allocate and decrypt
+// an unbounded amount of data per reconcile. MaxEntries matches the CRD's
+// MaxProperties marker on EncryptedData; MaxValueBytes is the base64-
+// encoded envelope size and is deliberately generous (the resulting Secret
+// is separately capped at ~1MiB by the apiserver).
+const (
+	MaxEntries    = 1024
+	MaxValueBytes = 1 << 20 // 1 MiB per encoded value
+)
+
 // AAD binds one ciphertext to exactly the object/key it was sealed for, so
 // an entry copied into a different GitSecret (or a renamed/moved one)
 // fails AEAD authentication instead of silently decrypting somewhere else.
@@ -135,8 +146,15 @@ func Unseal(namespace, name string, spec v1alpha1.GitSecretSpec) (map[string]str
 		return nil, fmt.Errorf("sealer: unwrapped content key is %d bytes, expected %d", len(key), keySize)
 	}
 
+	if len(spec.EncryptedData) > MaxEntries {
+		return nil, fmt.Errorf("sealer: encryptedData has %d entries, over the %d limit", len(spec.EncryptedData), MaxEntries)
+	}
+
 	data := make(map[string]string, len(spec.EncryptedData))
 	for k, encoded := range spec.EncryptedData {
+		if len(encoded) > MaxValueBytes {
+			return nil, fmt.Errorf("sealer: %q: encoded value is %d bytes, over the %d limit", k, len(encoded), MaxValueBytes)
+		}
 		envelope, err := base64.StdEncoding.DecodeString(encoded)
 		if err != nil {
 			return nil, fmt.Errorf("sealer: %q: not valid base64: %w", k, err)


### PR DESCRIPTION
First batch of the security-first backlog reset (#38–#48): the three P0 items.
No new features — this establishes the security documentation the repo lost when
`docs/adr/` was deleted, makes "recovery independence" a tested guarantee, and
closes three controller-safety gaps.

## #38 — threat model + design rationale (`40b3b4c`, `8ef1ced`)

- `docs/security/design-rationale.md` — the ADR-0001/0002 reasoning recovered
  from git history and reframed as history, not roadmap.
- `docs/security/threat-model.md` — assets, trust boundaries, 14 threats (key
  *loss* vs *compromise* as separate cases), 10 invariants, non-goals.
- `docs/security/threat-model.md` non-goals are explicit: malicious cluster admin
  and compromised operator workstation are **out of scope** (operational, not
  cryptographic, mitigations).
- `docs/architecture/overview.md` — ASCII diagrams of the seal→apply→reconcile
  flow, the two-layer envelope, and the loss-vs-compromise / recovery models.
- `SECURITY.md` — private vulnerability reporting.
- Repointed 5 dangling `docs/adr/000x` references in Go comments.

## #39 — disaster recovery, tested (`1bdcc0c`)

- `docs/security/disaster-recovery.md` — prerequisites (offline recovery
  recipient, controller-key backup, repo mirror) + per-scenario operator runbooks
  (A controller loss, B cluster loss, C key loss, D operator departure, E key
  compromise, F git rollback, G repo loss).
- `internal/sealer/recovery_test.go` — one test per scenario A–E, on throwaway
  GPG keys, no cluster. The compromise test (E) deliberately asserts the *limit*:
  the compromised key can't open the rewrapped object but **can** still open the
  pre-rewrap version from git history, so full value rotation + re-seal is
  required, not `--rewrap` alone.
- kind-level cluster e2e (controller redeploy / CRD reinstall) is deferred — the
  cryptographic core is covered here.

## #42 — controller safety (`a34ee52`)

- **Adoption guard.** `Reconcile` checked nothing before `CreateOrUpdate`, which
  will silently adopt an ownerless `Secret` whose name collides with a target —
  clearing its data and attaching an owner reference so it's deleted with the
  `GitSecret`. Now: ownership check first, `TargetConflict` Ready=False condition
  for a `Secret` it doesn't own, untouched unless the new `spec.target.adopt` is
  set.
- **Input bounds.** `sealer.Unseal` rejects an `encryptedData` map over 1024
  entries (also a CRD `maxProperties` marker) or any encoded value over 1 MiB.
- **Status-leak regression test.** `TestUnseal_ErrorDoesNotLeakPlaintext` locks
  in the "no plaintext in `.status`" invariant.
- Regenerated deepcopy + CRD (`config/crd/bases` + chart copy).

## Verification

`go build ./... && go vet ./... && go test ./...` green locally. No behaviour
change outside the #42 controller guard (which is covered by two new tests) and
the `sealer.Unseal` bounds (one new test).

## Follow-ups (not in this PR)

#40 recipient visibility on the object · #41 recipient lifecycle · #43
multi-cluster · #44 positioning docs · #45 gpg-default nudge · #46 sealing
console · #47 cluster keyring · #48 final docs + landing-page sweep gate.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT
