### PR TITLE
Recipient model: visibility on the object, roles, and lifecycle tooling (#40, #41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,11 @@ git-secret-seal --namespace myapp --name my-secrets \
 kubectl apply -f gitsecret.yaml   # git-secret-controller reconciles it into a plain Secret
 
 # Add/remove a recipient later without re-encrypting any value:
+git-secret-seal recipients add <new-fingerprint> -f gitsecret.yaml --role recovery
+git-secret-seal recipients remove <old-fingerprint> -f gitsecret.yaml
+git-secret-seal recipients list -f gitsecret.yaml       # who can decrypt, and their role
+
+# ...or set the whole list explicitly:
 git-secret-seal --rewrap gitsecret.yaml \
   --recipient <controller-fingerprint> --recipient <your-own-fingerprint> --recipient <new-fingerprint>
 ```
@@ -302,6 +307,8 @@ A container image and Helm chart ship on every tagged release
   seal → apply → reconcile flow, the two-layer envelope, and the recovery model.
 - [Disaster recovery](docs/security/disaster-recovery.md) — operator runbooks for
   controller loss, cluster loss, key loss, and key compromise.
+- [Recipient & key lifecycle](docs/security/recipient-lifecycle.md) — roles,
+  rotation workflows, and what removing a recipient does and doesn't undo.
 - [Reporting a vulnerability](SECURITY.md).
 
 The core property: the encrypted repository is the durable source of truth, and

--- a/README.md
+++ b/README.md
@@ -261,6 +261,13 @@ git-secret-seal --rewrap gitsecret.yaml \
   --recipient <controller-fingerprint> --recipient <your-own-fingerprint> --recipient <new-fingerprint>
 ```
 
+The generated manifest records the fingerprints it was sealed to in
+`spec.recipients`, so adding or removing a recipient shows up as a one-line
+change in review rather than an opaque blob churn. The controller mirrors this
+to `status.recipients` / `status.recipientCount` (a `Recipients` column on
+`kubectl get gitsecret`) so you can see who can decrypt an object without
+inspecting the ciphertext.
+
 Every `--recipient` must be a full 40/64-hex GPG fingerprint, not a short key
 ID or an email address — `git-secret-seal` rejects anything else, the same
 rule `.repo-enc.yml`'s `gpg_recipients` already enforces (see

--- a/api/v1alpha1/gitsecret_types.go
+++ b/api/v1alpha1/gitsecret_types.go
@@ -45,6 +45,18 @@ type GitSecretSpec struct {
 	// for whole-repo files.
 	EncryptedKey string `json:"encryptedKey"`
 
+	// Recipients lists the full GPG fingerprints EncryptedKey is wrapped
+	// to, sorted. Written by git-secret-seal. It is informational -- the
+	// authoritative recipient set is whatever EncryptedKey actually
+	// encrypts to -- but it makes "who can decrypt this object" reviewable
+	// in a plain YAML diff (adding a recipient becomes a visible one-line
+	// change) instead of requiring the armored blob to be inspected with
+	// gpg. sealer.VerifyRecipients cross-checks the count against the blob.
+	// +optional
+	// +listType=set
+	// +kubebuilder:validation:MaxItems=64
+	Recipients []string `json:"recipients,omitempty"`
+
 	// EncryptedData holds one ciphertext per target Secret key. Each value
 	// is a crypto.Seal envelope (see crypto/crypto.go), base64-std-encoded
 	// so it survives as plain YAML/JSON text, sealed under the key
@@ -84,6 +96,18 @@ type GitSecretStatus struct {
 	// written to match this object.
 	// +optional
 	LastSyncTime *metav1.Time `json:"lastSyncTime,omitempty"`
+
+	// Recipients mirrors spec.recipients as observed at the last reconcile,
+	// so `kubectl get gitsecret -o yaml` shows the current decrypt set
+	// without reading the spec. Empty if the object predates the field or
+	// was sealed by an older git-secret-seal.
+	// +optional
+	// +listType=set
+	Recipients []string `json:"recipients,omitempty"`
+
+	// RecipientCount is len(spec.recipients), surfaced as a printer column.
+	// +optional
+	RecipientCount int `json:"recipientCount,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -92,6 +116,7 @@ type GitSecretStatus struct {
 // +kubebuilder:printcolumn:name="Target",type=string,JSONPath=`.spec.target.name`,priority=0
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Keys",type=integer,JSONPath=`.status.syncedKeys`
+// +kubebuilder:printcolumn:name="Recipients",type=integer,JSONPath=`.status.recipientCount`
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // GitSecret decrypts into a plain Kubernetes Secret via a controller that

--- a/api/v1alpha1/recipientroles.go
+++ b/api/v1alpha1/recipientroles.go
@@ -1,0 +1,89 @@
+package v1alpha1
+
+import (
+	"sort"
+	"strings"
+)
+
+// RecipientRolesAnnotation carries the role of each recipient fingerprint
+// on a GitSecret, as a comma-separated "<fingerprint>:<role>" list, e.g.
+//
+//	git-secret.opscalehub.io/recipient-roles: "ABC...123:controller,DEF...456:recovery"
+//
+// It is a convention, not part of the decrypt path -- the controller never
+// consults it. Its purpose is operational: making it obvious which
+// recipients are the always-on controller identity, which are humans, and
+// which are the offline recovery keys that must never be removed.
+// git-secret-seal reads and writes it; a fingerprint with no entry is a
+// plain "human" recipient.
+const RecipientRolesAnnotation = "git-secret.opscalehub.io/recipient-roles"
+
+// RecipientRole classifies a recipient. See RecipientRolesAnnotation.
+type RecipientRole string
+
+const (
+	// RoleHuman is an operator who seals/reviews locally. The default when
+	// a fingerprint has no explicit role.
+	RoleHuman RecipientRole = "human"
+	// RoleController is a git-secret-controller identity (one per cluster).
+	RoleController RecipientRole = "controller"
+	// RoleRecovery is an offline key held outside any cluster and outside
+	// any operator's daily keyring -- the disaster-recovery backstop. Every
+	// production GitSecret should have at least one (threat-model
+	// invariant #1); git-secret-seal refuses to remove the last one
+	// without --force.
+	RoleRecovery RecipientRole = "recovery"
+	// RoleDeprecated is a recipient being phased out: still wrapped to, so
+	// it can still decrypt, but flagged so a later rewrap drops it.
+	RoleDeprecated RecipientRole = "deprecated"
+)
+
+// ValidRecipientRole reports whether r is one of the known roles.
+func ValidRecipientRole(r RecipientRole) bool {
+	switch r {
+	case RoleHuman, RoleController, RoleRecovery, RoleDeprecated:
+		return true
+	}
+	return false
+}
+
+// ParseRecipientRoles reads the RecipientRolesAnnotation value from
+// annotations. Unknown or malformed entries are skipped. Fingerprints are
+// upper-cased so lookups are case-insensitive.
+func ParseRecipientRoles(annotations map[string]string) map[string]RecipientRole {
+	out := map[string]RecipientRole{}
+	raw := annotations[RecipientRolesAnnotation]
+	if raw == "" {
+		return out
+	}
+	for _, part := range strings.Split(raw, ",") {
+		part = strings.TrimSpace(part)
+		fp, role, ok := strings.Cut(part, ":")
+		if !ok {
+			continue
+		}
+		fp = strings.ToUpper(strings.TrimSpace(fp))
+		rr := RecipientRole(strings.TrimSpace(role))
+		if fp == "" || !ValidRecipientRole(rr) {
+			continue
+		}
+		out[fp] = rr
+	}
+	return out
+}
+
+// FormatRecipientRoles renders roles back to an annotation value, sorted
+// by fingerprint for a stable diff. Entries with the default "human" role
+// are omitted to keep the annotation short; an empty result means the
+// caller should delete the annotation entirely.
+func FormatRecipientRoles(roles map[string]RecipientRole) string {
+	parts := make([]string, 0, len(roles))
+	for fp, role := range roles {
+		if role == "" || role == RoleHuman || !ValidRecipientRole(role) {
+			continue
+		}
+		parts = append(parts, strings.ToUpper(fp)+":"+string(role))
+	}
+	sort.Strings(parts)
+	return strings.Join(parts, ",")
+}

--- a/api/v1alpha1/recipientroles_test.go
+++ b/api/v1alpha1/recipientroles_test.go
@@ -1,0 +1,38 @@
+package v1alpha1
+
+import "testing"
+
+func TestParseAndFormatRecipientRoles(t *testing.T) {
+	const fpA = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+	const fpB = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+	const fpC = "CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+
+	ann := map[string]string{
+		RecipientRolesAnnotation: fpA + ":controller, " + fpB + ":recovery," + fpC + ":bogus",
+	}
+	roles := ParseRecipientRoles(ann)
+	if roles[fpA] != RoleController {
+		t.Errorf("fpA role = %q, want controller", roles[fpA])
+	}
+	if roles[fpB] != RoleRecovery {
+		t.Errorf("fpB role = %q, want recovery", roles[fpB])
+	}
+	if _, ok := roles[fpC]; ok {
+		t.Errorf("bogus role should have been dropped, got %q", roles[fpC])
+	}
+
+	// Round-trips, sorted, human/default omitted.
+	roles["dddd"] = RoleHuman
+	got := FormatRecipientRoles(roles)
+	want := fpA + ":controller," + fpB + ":recovery"
+	if got != want {
+		t.Errorf("FormatRecipientRoles = %q, want %q", got, want)
+	}
+
+	if FormatRecipientRoles(map[string]RecipientRole{"x": RoleHuman}) != "" {
+		t.Error("all-human map should format to empty (annotation should be deleted)")
+	}
+	if ParseRecipientRoles(nil) == nil {
+		t.Error("ParseRecipientRoles(nil) should return a non-nil empty map")
+	}
+}

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -72,6 +72,11 @@ func (in *GitSecretList) DeepCopyObject() runtime.Object {
 func (in *GitSecretSpec) DeepCopyInto(out *GitSecretSpec) {
 	*out = *in
 	out.Target = in.Target
+	if in.Recipients != nil {
+		in, out := &in.Recipients, &out.Recipients
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.EncryptedData != nil {
 		in, out := &in.EncryptedData, &out.EncryptedData
 		*out = make(map[string]string, len(*in))
@@ -104,6 +109,11 @@ func (in *GitSecretStatus) DeepCopyInto(out *GitSecretStatus) {
 	if in.LastSyncTime != nil {
 		in, out := &in.LastSyncTime, &out.LastSyncTime
 		*out = (*in).DeepCopy()
+	}
+	if in.Recipients != nil {
+		in, out := &in.Recipients, &out.Recipients
+		*out = make([]string, len(*in))
+		copy(*out, *in)
 	}
 }
 

--- a/charts/git-secret-controller/crds/gitsecret.yaml
+++ b/charts/git-secret-controller/crds/gitsecret.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.syncedKeys
       name: Keys
       type: integer
+    - jsonPath: .status.recipientCount
+      name: Recipients
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -91,6 +94,20 @@ spec:
                   same cheap-rewrap property keybackend.GPGBackend already relies on
                   for whole-repo files.
                 type: string
+              recipients:
+                description: |-
+                  Recipients lists the full GPG fingerprints EncryptedKey is wrapped
+                  to, sorted. Written by git-secret-seal. It is informational -- the
+                  authoritative recipient set is whatever EncryptedKey actually
+                  encrypts to -- but it makes "who can decrypt this object" reviewable
+                  in a plain YAML diff (adding a recipient becomes a visible one-line
+                  change) instead of requiring the armored blob to be inspected with
+                  gpg. sealer.VerifyRecipients cross-checks the count against the blob.
+                items:
+                  type: string
+                maxItems: 64
+                type: array
+                x-kubernetes-list-type: set
               target:
                 description: Target describes the Secret this object decrypts into.
                 properties:
@@ -192,6 +209,20 @@ spec:
                 description: ObservedGeneration is the .metadata.generation last reconciled.
                 format: int64
                 type: integer
+              recipientCount:
+                description: RecipientCount is len(spec.recipients), surfaced as a
+                  printer column.
+                type: integer
+              recipients:
+                description: |-
+                  Recipients mirrors spec.recipients as observed at the last reconcile,
+                  so `kubectl get gitsecret -o yaml` shows the current decrypt set
+                  without reading the spec. Empty if the object predates the field or
+                  was sealed by an older git-secret-seal.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
               syncedKeys:
                 description: |-
                   SyncedKeys is the number of EncryptedData entries currently

--- a/cmd/git-secret-seal/main.go
+++ b/cmd/git-secret-seal/main.go
@@ -79,6 +79,18 @@ Usage (rewrap -- add/remove a recipient without re-encrypting any value):
                                 include everyone who should still be able
                                 to decrypt, not just the one being added.
 
+Usage (recipients -- inspect/change the recipient set of an existing manifest):
+  git-secret-seal recipients list   -f FILE
+  git-secret-seal recipients add    FPR -f FILE [--role ROLE]
+  git-secret-seal recipients remove FPR -f FILE [--force]
+
+  Reads spec.recipients, rewraps to the new set (no value re-encrypted),
+  and prints the updated manifest. 'add'/'remove' need a local key that can
+  open FILE's encryptedKey; 'add' also needs FPR's public key. Roles
+  (human|controller|recovery|deprecated) are tracked in the
+  git-secret.opscalehub.io/recipient-roles annotation; 'remove' refuses to
+  drop the last recipient or the last 'recovery' one without --force.
+
 Exit codes: 0 ok, 1 error, 2 usage/key unavailable.
 `
 
@@ -101,6 +113,10 @@ func (s *stringSlice) Set(v string) error {
 }
 
 func run(args []string, stdout, stderr io.Writer) int {
+	if len(args) > 0 && args[0] == "recipients" {
+		return runRecipients(args[1:], stdout, stderr)
+	}
+
 	fs := flag.NewFlagSet("git-secret-seal", flag.ContinueOnError)
 	fs.SetOutput(stderr)
 	namespace := fs.String("namespace", "", "namespace for the GitSecret and (by default) its target Secret")

--- a/cmd/git-secret-seal/main_test.go
+++ b/cmd/git-secret-seal/main_test.go
@@ -100,6 +100,12 @@ func TestRun_LiteralsProduceDecryptableManifest(t *testing.T) {
 	if data["USERNAME"] != "admin" || data["PASSWORD"] != "hunter2" {
 		t.Errorf("round-trip mismatch: %#v", data)
 	}
+	if len(gs.Spec.Recipients) != 1 || gs.Spec.Recipients[0] != fpr {
+		t.Errorf("manifest spec.recipients = %v, want [%s]", gs.Spec.Recipients, fpr)
+	}
+	if !strings.Contains(stdout.String(), "recipients:") {
+		t.Error("manifest YAML does not surface a recipients: field")
+	}
 }
 
 func TestRun_FromSecretFile(t *testing.T) {

--- a/cmd/git-secret-seal/recipients.go
+++ b/cmd/git-secret-seal/recipients.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strings"
+
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/OpScaleHub/git-secret/api/v1alpha1"
+	"github.com/OpScaleHub/git-secret/internal/gpgutil"
+	"github.com/OpScaleHub/git-secret/internal/sealer"
+)
+
+const recipientsHelp = `git-secret-seal recipients - inspect and change a GitSecret's recipient set
+
+  git-secret-seal recipients list   -f FILE
+  git-secret-seal recipients add    FPR -f FILE [--role human|controller|recovery|deprecated]
+  git-secret-seal recipients remove FPR -f FILE [--force]
+
+'add' and 'remove' rewrap the content key to the new recipient list (no
+value is re-encrypted) and print the updated manifest on stdout. Both
+require a local GPG secret key that can already open FILE's encryptedKey --
+run them as one of the object's current recipients. 'add' additionally
+needs FPR's public key in your keyring.
+
+'remove' refuses to drop the last recipient, or the last recipient with
+role 'recovery', unless --force is given.
+`
+
+func runRecipients(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprint(stderr, recipientsHelp)
+		return exitUsage
+	}
+	sub := args[0]
+	rest := args[1:]
+
+	switch sub {
+	case "list":
+		return recipientsList(rest, stdout, stderr)
+	case "add":
+		return recipientsMutate(true, rest, stdout, stderr)
+	case "remove":
+		return recipientsMutate(false, rest, stdout, stderr)
+	case "-h", "--help", "help":
+		fmt.Fprint(stderr, recipientsHelp)
+		return exitUsage
+	default:
+		fmt.Fprintf(stderr, "error: unknown recipients subcommand %q\n\n%s", sub, recipientsHelp)
+		return exitUsage
+	}
+}
+
+func readGitSecret(path string) (*v1alpha1.GitSecret, error) {
+	var raw []byte
+	var err error
+	if path == "-" {
+		raw, err = io.ReadAll(os.Stdin)
+	} else {
+		raw, err = os.ReadFile(path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", path, err)
+	}
+	var gs v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal(raw, &gs); err != nil {
+		return nil, fmt.Errorf("parse %s as a GitSecret manifest: %w", path, err)
+	}
+	if gs.Kind != "" && gs.Kind != "GitSecret" {
+		return nil, fmt.Errorf("%s is a %s manifest, not a GitSecret", path, gs.Kind)
+	}
+	return &gs, nil
+}
+
+func recipientsList(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("recipients list", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	file := fs.String("f", "", "path to the GitSecret manifest (- for stdin)")
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	if *file == "" {
+		fmt.Fprintln(stderr, "error: -f FILE is required")
+		return exitUsage
+	}
+	gs, err := readGitSecret(*file)
+	if err != nil {
+		fmt.Fprintln(stderr, "error:", err)
+		return exitError
+	}
+	if len(gs.Spec.Recipients) == 0 {
+		fmt.Fprintln(stderr, "note: spec.recipients is empty (sealed by an older git-secret-seal?)")
+		return exitOK
+	}
+	roles := v1alpha1.ParseRecipientRoles(gs.Annotations)
+	sorted := append([]string(nil), gs.Spec.Recipients...)
+	sort.Strings(sorted)
+	for _, fp := range sorted {
+		role := roles[strings.ToUpper(fp)]
+		if role == "" {
+			role = v1alpha1.RoleHuman
+		}
+		fmt.Fprintf(stdout, "%s\t%s\n", fp, role)
+	}
+	return exitOK
+}
+
+func recipientsMutate(add bool, args []string, stdout, stderr io.Writer) int {
+	verb := "add"
+	if !add {
+		verb = "remove"
+	}
+	fs := flag.NewFlagSet("recipients "+verb, flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	file := fs.String("f", "", "path to the GitSecret manifest (- for stdin)")
+	role := fs.String("role", "", "role for the added recipient (human|controller|recovery|deprecated)")
+	force := fs.Bool("force", false, "allow removing the last recipient or the last recovery recipient")
+	// Two-pass parse so the fingerprint positional can appear before or
+	// after the flags (Go's flag package otherwise stops at the first
+	// non-flag token).
+	if err := fs.Parse(args); err != nil {
+		return exitUsage
+	}
+	var fpr string
+	if rest := fs.Args(); len(rest) > 0 {
+		fpr = rest[0]
+		if err := fs.Parse(rest[1:]); err != nil {
+			return exitUsage
+		}
+	}
+	if fpr == "" || fs.NArg() != 0 {
+		fmt.Fprintf(stderr, "error: exactly one fingerprint argument is required\n\n%s", recipientsHelp)
+		return exitUsage
+	}
+	if !gpgutil.ValidFingerprint(fpr) {
+		fmt.Fprintf(stderr, "error: %q is not a full 40/64-hex GPG fingerprint\n", fpr)
+		return exitUsage
+	}
+	if *file == "" {
+		fmt.Fprintln(stderr, "error: -f FILE is required")
+		return exitUsage
+	}
+	if !add && *role != "" {
+		fmt.Fprintln(stderr, "error: --role only applies to 'add'")
+		return exitUsage
+	}
+	if *role != "" && !v1alpha1.ValidRecipientRole(v1alpha1.RecipientRole(*role)) {
+		fmt.Fprintf(stderr, "error: %q is not a valid role (human|controller|recovery|deprecated)\n", *role)
+		return exitUsage
+	}
+	if !gpgutil.Available() {
+		fmt.Fprintln(stderr, "error: gpg binary not found on PATH")
+		return exitError
+	}
+
+	gs, err := readGitSecret(*file)
+	if err != nil {
+		fmt.Fprintln(stderr, "error:", err)
+		return exitError
+	}
+
+	current := map[string]bool{}
+	for _, r := range gs.Spec.Recipients {
+		current[strings.ToUpper(r)] = true
+	}
+	roles := v1alpha1.ParseRecipientRoles(gs.Annotations)
+	key := strings.ToUpper(fpr)
+
+	var next []string
+	if add {
+		if current[key] {
+			fmt.Fprintf(stderr, "error: %s is already a recipient\n", fpr)
+			return exitError
+		}
+		next = append(append([]string(nil), gs.Spec.Recipients...), fpr)
+		if *role != "" {
+			roles[key] = v1alpha1.RecipientRole(*role)
+		}
+	} else {
+		if !current[key] {
+			fmt.Fprintf(stderr, "error: %s is not a current recipient\n", fpr)
+			return exitError
+		}
+		for _, r := range gs.Spec.Recipients {
+			if strings.ToUpper(r) != key {
+				next = append(next, r)
+			}
+		}
+		if len(next) == 0 && !*force {
+			fmt.Fprintln(stderr, "error: refusing to remove the last recipient (this would make the object permanently undecryptable); pass --force if you really mean it")
+			return exitError
+		}
+		if !*force && roles[key] == v1alpha1.RoleRecovery && !hasRole(next, roles, v1alpha1.RoleRecovery) {
+			fmt.Fprintln(stderr, "error: refusing to remove the last recovery recipient; pass --force to override")
+			return exitError
+		}
+		delete(roles, key)
+	}
+
+	newSpec, err := sealer.Rewrap(gs.Spec, next)
+	if err != nil {
+		fmt.Fprintln(stderr, "error:", err)
+		return exitError
+	}
+	gs.Spec = newSpec
+
+	roleStr := v1alpha1.FormatRecipientRoles(roles)
+	if roleStr == "" {
+		delete(gs.Annotations, v1alpha1.RecipientRolesAnnotation)
+		if len(gs.Annotations) == 0 {
+			gs.Annotations = nil
+		}
+	} else {
+		if gs.Annotations == nil {
+			gs.Annotations = map[string]string{}
+		}
+		gs.Annotations[v1alpha1.RecipientRolesAnnotation] = roleStr
+	}
+
+	out, err := sigsyaml.Marshal(gs)
+	if err != nil {
+		fmt.Fprintln(stderr, "error: marshal manifest:", err)
+		return exitError
+	}
+	stdout.Write(out)
+	return exitOK
+}
+
+func hasRole(fps []string, roles map[string]v1alpha1.RecipientRole, want v1alpha1.RecipientRole) bool {
+	for _, fp := range fps {
+		if roles[strings.ToUpper(fp)] == want {
+			return true
+		}
+	}
+	return false
+}

--- a/cmd/git-secret-seal/recipients_test.go
+++ b/cmd/git-secret-seal/recipients_test.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/OpScaleHub/git-secret/api/v1alpha1"
+	"github.com/OpScaleHub/git-secret/internal/sealer"
+)
+
+// sealManifest runs the seal path and returns the manifest bytes + path.
+func sealManifest(t *testing.T, gnupgHome, fpr string) (string, []byte) {
+	t.Helper()
+	t.Setenv("GNUPGHOME", gnupgHome)
+	var out, errb bytes.Buffer
+	if code := run([]string{"--namespace", "ns", "--name", "obj", "--recipient", fpr, "--from-literal", "K=v"}, &out, &errb); code != exitOK {
+		t.Fatalf("seal run() = %d: %s", code, errb.String())
+	}
+	path := t.TempDir() + "/gitsecret.yaml"
+	if err := os.WriteFile(path, out.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path, out.Bytes()
+}
+
+func TestRecipients_ListAndAddAndRemove(t *testing.T) {
+	homeA := shortTempDir(t)
+	fprA := genTestKey(t, homeA)
+	path, _ := sealManifest(t, homeA, fprA)
+
+	// list: one human recipient.
+	var lsOut, lsErr bytes.Buffer
+	if code := run([]string{"recipients", "list", "-f", path}, &lsOut, &lsErr); code != exitOK {
+		t.Fatalf("list = %d: %s", code, lsErr.String())
+	}
+	if !strings.Contains(lsOut.String(), fprA) || !strings.Contains(lsOut.String(), "human") {
+		t.Fatalf("list output = %q", lsOut.String())
+	}
+
+	// add B as a recovery recipient.
+	homeB := shortTempDir(t)
+	fprB := genTestKey(t, homeB)
+	importPublicKeyCLI(t, homeA, exportPublicKeyCLI(t, homeB, fprB))
+	t.Setenv("GNUPGHOME", homeA)
+
+	var addOut, addErr bytes.Buffer
+	if code := run([]string{"recipients", "add", fprB, "-f", path, "--role", "recovery"}, &addOut, &addErr); code != exitOK {
+		t.Fatalf("add = %d: %s", code, addErr.String())
+	}
+	var gs v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal(addOut.Bytes(), &gs); err != nil {
+		t.Fatal(err)
+	}
+	if len(gs.Spec.Recipients) != 2 {
+		t.Fatalf("after add, recipients = %v", gs.Spec.Recipients)
+	}
+	if v1alpha1.ParseRecipientRoles(gs.Annotations)[strings.ToUpper(fprB)] != v1alpha1.RoleRecovery {
+		t.Fatalf("B role not recorded: %v", gs.Annotations)
+	}
+	// B can now decrypt.
+	t.Setenv("GNUPGHOME", homeB)
+	if _, err := sealer.Unseal("ns", "obj", gs.Spec); err != nil {
+		t.Fatalf("B cannot decrypt after add: %v", err)
+	}
+
+	// Write the 2-recipient manifest back, then removing the recovery one
+	// (B) must be refused without --force.
+	if err := os.WriteFile(path, addOut.Bytes(), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GNUPGHOME", homeA)
+	var rmOut, rmErr bytes.Buffer
+	if code := run([]string{"recipients", "remove", fprB, "-f", path}, &rmOut, &rmErr); code == exitOK {
+		t.Fatalf("remove of last recovery recipient should have failed; got ok, stderr=%s", rmErr.String())
+	}
+	if !strings.Contains(rmErr.String(), "recovery") {
+		t.Fatalf("unexpected refusal message: %s", rmErr.String())
+	}
+
+	// --force lets it through.
+	var frOut, frErr bytes.Buffer
+	if code := run([]string{"recipients", "remove", fprB, "-f", path, "--force"}, &frOut, &frErr); code != exitOK {
+		t.Fatalf("forced remove = %d: %s", code, frErr.String())
+	}
+	var after v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal(frOut.Bytes(), &after); err != nil {
+		t.Fatal(err)
+	}
+	if len(after.Spec.Recipients) != 1 || after.Spec.Recipients[0] != fprA {
+		t.Fatalf("after forced remove, recipients = %v", after.Spec.Recipients)
+	}
+	if _, ok := after.Annotations[v1alpha1.RecipientRolesAnnotation]; ok {
+		t.Fatalf("roles annotation should be gone, got %v", after.Annotations)
+	}
+}
+
+func TestRecipients_RemoveLastIsRefused(t *testing.T) {
+	home := shortTempDir(t)
+	fpr := genTestKey(t, home)
+	path, _ := sealManifest(t, home, fpr)
+
+	var out, errb bytes.Buffer
+	if code := run([]string{"recipients", "remove", fpr, "-f", path}, &out, &errb); code == exitOK {
+		t.Fatal("removing the only recipient should be refused")
+	}
+	if !strings.Contains(errb.String(), "last recipient") {
+		t.Fatalf("unexpected message: %s", errb.String())
+	}
+}

--- a/config/crd/bases/git-secret.opscalehub.io_gitsecrets.yaml
+++ b/config/crd/bases/git-secret.opscalehub.io_gitsecrets.yaml
@@ -26,6 +26,9 @@ spec:
     - jsonPath: .status.syncedKeys
       name: Keys
       type: integer
+    - jsonPath: .status.recipientCount
+      name: Recipients
+      type: integer
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -91,6 +94,20 @@ spec:
                   same cheap-rewrap property keybackend.GPGBackend already relies on
                   for whole-repo files.
                 type: string
+              recipients:
+                description: |-
+                  Recipients lists the full GPG fingerprints EncryptedKey is wrapped
+                  to, sorted. Written by git-secret-seal. It is informational -- the
+                  authoritative recipient set is whatever EncryptedKey actually
+                  encrypts to -- but it makes "who can decrypt this object" reviewable
+                  in a plain YAML diff (adding a recipient becomes a visible one-line
+                  change) instead of requiring the armored blob to be inspected with
+                  gpg. sealer.VerifyRecipients cross-checks the count against the blob.
+                items:
+                  type: string
+                maxItems: 64
+                type: array
+                x-kubernetes-list-type: set
               target:
                 description: Target describes the Secret this object decrypts into.
                 properties:
@@ -192,6 +209,20 @@ spec:
                 description: ObservedGeneration is the .metadata.generation last reconciled.
                 format: int64
                 type: integer
+              recipientCount:
+                description: RecipientCount is len(spec.recipients), surfaced as a
+                  printer column.
+                type: integer
+              recipients:
+                description: |-
+                  Recipients mirrors spec.recipients as observed at the last reconcile,
+                  so `kubectl get gitsecret -o yaml` shows the current decrypt set
+                  without reading the spec. Empty if the object predates the field or
+                  was sealed by an older git-secret-seal.
+                items:
+                  type: string
+                type: array
+                x-kubernetes-list-type: set
               syncedKeys:
                 description: |-
                   SyncedKeys is the number of EncryptedData entries currently

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -69,6 +69,10 @@ Adding/removing a recipient (`git-secret-seal --rewrap`) re-encrypts **only the
 right-hand box**. Every `encryptedData` value is untouched — that is what makes
 recipient changes cheap and key loss recoverable.
 
+`spec.recipients` lists those fingerprints in plaintext on the object (mirrored to
+`status.recipients`), so the decrypt set is reviewable in a YAML diff;
+`sealer.VerifyRecipients` cross-checks its count against the wrapped blob.
+
 ## Trust model: why loss ≠ compromise
 
 ```

--- a/docs/security/disaster-recovery.md
+++ b/docs/security/disaster-recovery.md
@@ -93,12 +93,15 @@ Proven by `TestRecovery_ControllerKeyLost_HumanRewrapsToNewController`.
 
 ## D — operator leaves
 
-Rewrap every object they were a recipient of, dropping their fingerprint:
+Drop their fingerprint from every object they were a recipient of:
 
 ```
-git-secret-seal --rewrap gitsecret.yaml \
-  --recipient <controller-fpr> --recipient <remaining-human-fpr> --recipient <recovery-fpr>
+git-secret-seal recipients remove <departing-fpr> -f gitsecret.yaml
 ```
+
+(or, to set the whole list explicitly, `git-secret-seal --rewrap gitsecret.yaml
+--recipient <controller-fpr> --recipient <remaining-human-fpr> --recipient
+<recovery-fpr>`).
 
 They can no longer decrypt any **future** version of the object. They **can**
 still decrypt any version already in Git history that was wrapped to them — if

--- a/docs/security/recipient-lifecycle.md
+++ b/docs/security/recipient-lifecycle.md
@@ -1,0 +1,80 @@
+# Recipient & key lifecycle
+
+Multi-recipient GPG is the project's core differentiator, but "a flat list of
+fingerprints" is not a lifecycle. This document defines the roles a recipient can
+have, the workflows for changing the set, and — importantly — what those changes
+do and do **not** protect against.
+
+Companion to [disaster-recovery.md](disaster-recovery.md) (the incident runbooks)
+and [threat-model.md](threat-model.md) T3/T4/T11.
+
+## Recipient roles
+
+Roles are a **convention**, recorded in the
+`git-secret.opscalehub.io/recipient-roles` annotation on the `GitSecret`
+(`<fingerprint>:<role>`, comma-separated). The controller never reads them — the
+decrypt path only cares what `encryptedKey` is actually wrapped to. They exist so
+an operator can tell at a glance which key is which.
+
+| Role | What it is | Notes |
+|---|---|---|
+| `human` | An operator who seals / reviews locally | The default when a fingerprint has no entry |
+| `controller` | A `git-secret-controller` identity | One per cluster (see [multi-cluster](../architecture/overview.md)) |
+| `recovery` | An offline key, held outside any cluster and outside any daily-use keyring | **Every production `GitSecret` should have one.** `git-secret-seal` refuses to remove the last one without `--force` |
+| `deprecated` | A recipient being phased out — still wrapped to, flagged for a later rewrap to drop | |
+
+## "Who can decrypt this object?"
+
+```
+git-secret-seal recipients list -f gitsecret.yaml
+```
+
+prints each fingerprint and its role. The set also appears as `spec.recipients`
+in the manifest and `status.recipients` on the live object
+(`kubectl get gitsecret` shows a `Recipients` count column).
+
+## Workflows
+
+| Change | Command | Re-seal values? | Historical exposure? |
+|---|---|---|---|
+| Add a recipient | `git-secret-seal recipients add <fpr> -f f.yaml [--role R]` | No | — |
+| Remove a recipient (clean) | `git-secret-seal recipients remove <fpr> -f f.yaml` | No | They keep access to versions already in Git history |
+| Rotate the controller identity | `recipients add <new>` then `recipients remove <old>` | No | — |
+| Rotate a **compromised** key | full `git-secret-seal` re-seal + rotate the secret values themselves | **Yes** | Permanent for anything ever committed — see below |
+| Emergency: rotate everything | re-seal every `GitSecret` to a fresh recipient set | Yes | As above |
+
+`add` / `remove` rewrap the content key to the new set and print the updated
+manifest; commit it and the controller reconciles. Both need a local GPG secret
+key that can already open the object (run them as a current recipient); `add`
+also needs the new fingerprint's public key in your keyring (`gpg --import`, WKD,
+or a keyserver — see #47 for making this discoverable).
+
+## Key expiry
+
+A GPG recipient key can expire. The controller does **not** fail an existing
+object on recipient-key expiry (the data is already there and still decryptable
+by the controller's own key), but surfacing an early warning
+(`RecipientKeyExpiring` condition / metric) is planned. Until then: track expiry
+out of band and `recipients add` a renewed key before the old one lapses.
+
+## Historical ciphertext — the property to understand
+
+Because a `GitSecret` is delivered through Git, **every prior version of the
+object stays in Git history**, each wrapped to whatever recipient set it had at
+the time. Consequences:
+
+- **Removing a recipient** stops them decrypting *new* object versions. It does
+  **nothing** about versions already in history that were wrapped to them, which
+  they can still open if they have a copy of the repo. For a departing operator
+  who was only ever a passive reviewer this is usually fine; treat it as a
+  compromise (below) if it isn't.
+- **A compromised key** must be assumed to have decrypted everything that key was
+  ever a recipient of, across all of history. `--rewrap` / `recipients remove`
+  cannot reach into history. The only real remediation is to **rotate the secret
+  values at their source** (new DB password, new token) and re-seal — see
+  [disaster-recovery.md §E](disaster-recovery.md#e--recipient-key-compromised).
+
+This is not a flaw to fix — Git history is immutable by design — it is a property
+to design around: keep genuinely long-lived, un-rotatable secrets out of Git, and
+give every production object a `recovery` recipient so a compromise never forces
+an unrecoverable state.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -81,7 +81,7 @@ Notation: **L** = availability/recovery, **C** = confidentiality, **I** = integr
 | T8 | Malicious cluster administrator | C | **Out of scope.** Anyone who can `kubectl get secret -o yaml` wins without touching `git-secret`. |
 | T9 | Compromised controller pod | C | Blast radius = `GitSecret`s wrapped to the controller key. Mitigation: don't wrap every object to every controller (per-cluster/per-env recipients, #43); `runAsNonRoot`, read-only rootfs, minimal RBAC. |
 | T10 | Rollback / history-rewrite of a `GitSecret` in Git | I | An old object version re-applied re-installs old secret values silently. Provenance (which Git revision produced this Secret) is not surfaced — future work. |
-| T11 | Recipient substitution — object sealed to an attacker key alongside the real ones | C | **Gap (#40).** Recipients are not visible on the object; a reviewer cannot see who an object is sealed to without inspecting the armored blob (which carries key IDs, not fingerprints). |
+| T11 | Recipient substitution — object sealed to an attacker key alongside the real ones | C | **Partial.** `spec.recipients` now lists the fingerprints on the object, so adding one is a visible one-line diff in review; `sealer.VerifyRecipients` cross-checks the count against the blob and the controller logs a warning on mismatch. Not yet enforced by admission (#41). |
 | T12 | Pre-existing target `Secret` silently adopted & cleared | I | **Handled.** A colliding `Secret` this `GitSecret` does not own is left untouched and a `TargetConflict` Ready=False condition is set, unless the operator opts in with `spec.target.adopt`. Tests `TestReconcile_DoesNotClobberUnownedSecret` / `_AdoptsUnownedSecretWhenOptedIn`. |
 | T13 | Plaintext committed to Git (CLI path) | C | **Handled.** `verify` + the `pre-push` hook fail closed; `SECRETIZE_SKIP_HOOKS` is opt-in per-invocation, never tied to ambient `CI`. |
 | T14 | Recipient specified as a short key ID / email, resolving to the wrong key | C | **Handled.** `gpgutil.ValidFingerprint` requires a full 40/64-hex fingerprint everywhere recipients are accepted. |
@@ -134,8 +134,9 @@ regression regardless of the feature it enables.
 
 ## 6. Open items feeding this model
 
-#40 (recipient visibility) · #41 (recipient lifecycle) · #43 (multi-cluster blast
-radius) · #47 (keyring / pubkey discovery).
+#41 (recipient lifecycle / admission) · #43 (multi-cluster blast radius) · #47
+(keyring / pubkey discovery).
 
-Closed: #38 (this doc) · #39 (DR runbooks + tests) · #42 (controller adoption
-guard, input bounds, status-leak regression test).
+Closed: #38 (this doc) · #39 (DR runbooks + tests) · #40 (`spec.recipients` +
+status mirror + `VerifyRecipients`) · #42 (controller adoption guard, input
+bounds, status-leak regression test).

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -134,9 +134,10 @@ regression regardless of the feature it enables.
 
 ## 6. Open items feeding this model
 
-#41 (recipient lifecycle / admission) · #43 (multi-cluster blast radius) · #47
-(keyring / pubkey discovery).
+#43 (multi-cluster blast radius) · #47 (keyring / pubkey discovery) · admission
+enforcement of `spec.recipients` (deferred from #41).
 
 Closed: #38 (this doc) · #39 (DR runbooks + tests) · #40 (`spec.recipients` +
-status mirror + `VerifyRecipients`) · #42 (controller adoption guard, input
-bounds, status-leak regression test).
+status mirror + `VerifyRecipients`) · #41 (recipient roles + `git-secret-seal
+recipients` + [lifecycle doc](recipient-lifecycle.md)) · #42 (controller adoption
+guard, input bounds, status-leak regression test).

--- a/internal/controller/gitsecret_controller.go
+++ b/internal/controller/gitsecret_controller.go
@@ -59,6 +59,19 @@ func (r *GitSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		targetName = gs.Name
 	}
 
+	// Mirror the declared recipient set into status regardless of what
+	// happens below, so `kubectl get gitsecret` shows who can decrypt an
+	// object even while it is failing to reconcile.
+	gs.Status.Recipients = gs.Spec.Recipients
+	gs.Status.RecipientCount = len(gs.Spec.Recipients)
+	if err := sealer.VerifyRecipients(gs.Spec); err != nil {
+		// Non-fatal: the authoritative recipient set is the blob itself,
+		// which the decrypt path below uses directly. A mismatch just
+		// means spec.recipients is stale/wrong as documentation -- worth
+		// a warning, not a reconcile failure.
+		logger.Info("spec.recipients does not match encryptedKey", "gitsecret", req.NamespacedName, "reason", err.Error())
+	}
+
 	data, unsealErr := sealer.Unseal(gs.Namespace, gs.Name, gs.Spec)
 	if unsealErr != nil {
 		logger.Error(unsealErr, "unseal failed", "gitsecret", req.NamespacedName)

--- a/internal/controller/gitsecret_controller_test.go
+++ b/internal/controller/gitsecret_controller_test.go
@@ -137,6 +137,9 @@ func TestReconcile_CreatesTargetSecret(t *testing.T) {
 	if updated.Status.SyncedKeys != 2 {
 		t.Errorf("status.syncedKeys = %d, want 2", updated.Status.SyncedKeys)
 	}
+	if updated.Status.RecipientCount != 1 || len(updated.Status.Recipients) != 1 || updated.Status.Recipients[0] != fpr {
+		t.Errorf("status recipients = %v (count %d), want [%s] (1)", updated.Status.Recipients, updated.Status.RecipientCount, fpr)
+	}
 	found := false
 	for _, c := range updated.Status.Conditions {
 		if c.Type == conditionReady {

--- a/internal/gpgutil/gpgutil.go
+++ b/internal/gpgutil/gpgutil.go
@@ -172,6 +172,24 @@ func ImportSecretKey(armored []byte) error {
 	return nil
 }
 
+// CountRecipients returns how many public-key recipients an armored GPG
+// message is encrypted to, counting its pubkey-enc packets. It does not
+// resolve them to fingerprints -- the packet carries a recipient's
+// encryption-subkey ID, not the primary-key fingerprint -- so this is a
+// count check only (see sealer.VerifyRecipients). --list-packets does not
+// decrypt, so no secret key or agent is required.
+func CountRecipients(armored []byte) (int, error) {
+	out, err := run(armored, "--batch", "--list-packets")
+	if err != nil {
+		return 0, fmt.Errorf("gpgutil: list-packets: %w", err)
+	}
+	n := bytes.Count(out, []byte("pubkey enc packet"))
+	if n == 0 {
+		return 0, fmt.Errorf("gpgutil: no pubkey-enc packets in message")
+	}
+	return n, nil
+}
+
 // run executes gpg with args, piping stdin (if non-nil) and capturing
 // stdout/stderr. --trust-model always (on Encrypt) bypasses gpg's own
 // web-of-trust confirmation prompt, which would otherwise hang forever

--- a/internal/gpgutil/gpgutil_test.go
+++ b/internal/gpgutil/gpgutil_test.go
@@ -246,3 +246,39 @@ func TestImportSecretKey_GarbageInput(t *testing.T) {
 		t.Fatal("expected an error importing garbage input")
 	}
 }
+
+func TestCountRecipients(t *testing.T) {
+	fpr1 := newTestKeyring(t, "Count One <count1@example.com>")
+
+	one, err := Encrypt([]byte("x"), []string{fpr1})
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+	if n, err := CountRecipients(one); err != nil || n != 1 {
+		t.Fatalf("CountRecipients(1 recipient) = %d, %v; want 1, nil", n, err)
+	}
+
+	// Add a second key to the same keyring and encrypt to both.
+	cmd := exec.Command(Binary, "--batch", "--passphrase", "", "--quick-generate-key", "Count Two <count2@example.com>", "default", "default", "never")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("generate second key: %v: %s", err, stderr.String())
+	}
+	keys, err := ListSecretKeys()
+	if err != nil || len(keys) != 2 {
+		t.Fatalf("ListSecretKeys: %v (got %d)", err, len(keys))
+	}
+
+	two, err := Encrypt([]byte("x"), []string{keys[0].Fingerprint, keys[1].Fingerprint})
+	if err != nil {
+		t.Fatalf("Encrypt(2): %v", err)
+	}
+	if n, err := CountRecipients(two); err != nil || n != 2 {
+		t.Fatalf("CountRecipients(2 recipients) = %d, %v; want 2, nil", n, err)
+	}
+
+	if _, err := CountRecipients([]byte("not a pgp message")); err == nil {
+		t.Fatal("CountRecipients accepted garbage")
+	}
+}

--- a/internal/sealer/recipients_test.go
+++ b/internal/sealer/recipients_test.go
@@ -1,0 +1,93 @@
+package sealer
+
+import (
+	"testing"
+)
+
+func TestSeal_PopulatesSortedRecipients(t *testing.T) {
+	homeA := shortTempDir(t)
+	fprA := genTestKey(t, homeA)
+	homeB := shortTempDir(t)
+	fprB := genTestKey(t, homeB)
+
+	// Seal (in A's keyring) needs B's public key too.
+	importPublicKey(t, homeA, exportPublicKey(t, homeB, fprB))
+	t.Setenv("GNUPGHOME", homeA)
+
+	// Pass out of order; spec.Recipients must come back sorted and stable.
+	hi, lo := fprA, fprB
+	if hi < lo {
+		hi, lo = lo, hi
+	}
+	spec, err := Seal("prod", "app", map[string]string{"K": "v"}, []string{hi, lo})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if len(spec.Recipients) != 2 || spec.Recipients[0] != lo || spec.Recipients[1] != hi {
+		t.Fatalf("spec.Recipients = %v, want sorted [%s %s]", spec.Recipients, lo, hi)
+	}
+	if err := VerifyRecipients(spec); err != nil {
+		t.Fatalf("VerifyRecipients on fresh Seal output: %v", err)
+	}
+}
+
+func TestRewrap_ReplacesRecipients(t *testing.T) {
+	homeA := shortTempDir(t)
+	fprA := genTestKey(t, homeA)
+	homeB := shortTempDir(t)
+	fprB := genTestKey(t, homeB)
+
+	importPublicKey(t, homeA, exportPublicKey(t, homeB, fprB))
+	t.Setenv("GNUPGHOME", homeA)
+
+	spec, err := Seal("prod", "app", map[string]string{"K": "v"}, []string{fprA})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	if len(spec.Recipients) != 1 {
+		t.Fatalf("initial Recipients = %v", spec.Recipients)
+	}
+
+	rewrapped, err := Rewrap(spec, []string{fprA, fprB})
+	if err != nil {
+		t.Fatalf("Rewrap: %v", err)
+	}
+	if len(rewrapped.Recipients) != 2 {
+		t.Fatalf("rewrapped Recipients = %v, want 2", rewrapped.Recipients)
+	}
+	if err := VerifyRecipients(rewrapped); err != nil {
+		t.Fatalf("VerifyRecipients after Rewrap: %v", err)
+	}
+}
+
+func TestVerifyRecipients_DetectsDrift(t *testing.T) {
+	home := shortTempDir(t)
+	fpr := genTestKey(t, home)
+	t.Setenv("GNUPGHOME", home)
+
+	spec, err := Seal("prod", "app", map[string]string{"K": "v"}, []string{fpr})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+
+	// Empty Recipients -> nothing claimed, VerifyRecipients is a no-op.
+	noClaim := spec
+	noClaim.Recipients = nil
+	if err := VerifyRecipients(noClaim); err != nil {
+		t.Fatalf("VerifyRecipients with no claim should pass: %v", err)
+	}
+
+	// Claim two recipients when the blob only has one.
+	drifted := spec
+	drifted.Recipients = []string{fpr, "0000000000000000000000000000000000000000"}
+	if err := VerifyRecipients(drifted); err == nil {
+		t.Fatal("VerifyRecipients did not catch a recipient-count mismatch")
+	}
+
+	// A non-fingerprint entry is rejected outright.
+	bad := spec
+	bad.Recipients = []string{"DEADBEEF"}
+	if err := VerifyRecipients(bad); err == nil {
+		t.Fatal("VerifyRecipients accepted a short key ID in spec.recipients")
+	}
+}

--- a/internal/sealer/sealer.go
+++ b/internal/sealer/sealer.go
@@ -86,7 +86,17 @@ func Seal(namespace, name string, data map[string]string, recipients []string) (
 	return v1alpha1.GitSecretSpec{
 		EncryptedKey:  string(wrappedKey),
 		EncryptedData: encData,
+		Recipients:    sortedCopy(recipients),
 	}, nil
+}
+
+// sortedCopy returns a sorted copy of in, leaving the caller's slice
+// untouched -- used so spec.Recipients is diff-stable regardless of the
+// order recipients were passed on the command line.
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
 }
 
 // Rewrap re-encrypts spec's content key to newRecipients without touching
@@ -127,7 +137,37 @@ func Rewrap(spec v1alpha1.GitSecretSpec, newRecipients []string) (v1alpha1.GitSe
 
 	out := spec
 	out.EncryptedKey = string(wrapped)
+	out.Recipients = sortedCopy(newRecipients)
 	return out, nil
+}
+
+// VerifyRecipients cross-checks spec.Recipients against the number of
+// public-key recipients EncryptedKey is actually wrapped to. It is a
+// drift check, not full authentication: it catches a recipient added to
+// (or removed from) the armored blob without a matching spec.Recipients
+// edit, or vice versa. It does not (cannot cheaply) prove each listed
+// fingerprint is one of the blob's recipients, because the blob carries
+// encryption-subkey IDs, not primary-key fingerprints.
+//
+// Returns nil when spec.Recipients is empty (nothing claimed, nothing to
+// check -- e.g. an object sealed by an older git-secret-seal).
+func VerifyRecipients(spec v1alpha1.GitSecretSpec) error {
+	if len(spec.Recipients) == 0 {
+		return nil
+	}
+	for _, r := range spec.Recipients {
+		if !gpgutil.ValidFingerprint(r) {
+			return fmt.Errorf("sealer: spec.recipients entry %q is not a full GPG fingerprint", r)
+		}
+	}
+	n, err := gpgutil.CountRecipients([]byte(spec.EncryptedKey))
+	if err != nil {
+		return fmt.Errorf("sealer: %w", err)
+	}
+	if n != len(spec.Recipients) {
+		return fmt.Errorf("sealer: spec.recipients lists %d fingerprint(s) but encryptedKey is wrapped to %d recipient(s)", len(spec.Recipients), n)
+	}
+	return nil
 }
 
 // Unseal reverses Seal using whatever local GPG secret key (via gpg-agent


### PR DESCRIPTION
The recipient-model batch of the backlog reset (#40, #41). Builds on the merged
security foundation (#49). No breaking changes; one additive CRD field.

## #40 — recipients on the object + status (`b12a588`)

You could not tell who could decrypt a `GitSecret` without pulling the armored
blob and running `gpg` on it (which yields subkey IDs, not fingerprints).

- `GitSecretSpec.Recipients []string` — full fingerprints `encryptedKey` is
  wrapped to, sorted, written by `sealer.Seal` / `sealer.Rewrap`. Emitted by
  `git-secret-seal`, so adding a recipient is a one-line YAML diff in review.
- `GitSecretStatus.Recipients` / `RecipientCount` — mirrored by the controller
  every reconcile (even on failure); `Recipients` printer column on
  `kubectl get gitsecret`.
- `sealer.VerifyRecipients` + `gpgutil.CountRecipients` — drift check: the
  fingerprint count in `spec.recipients` must match the pubkey-enc packet count
  in the blob. Count-only (the blob carries encryption-subkey IDs, not primary
  fingerprints); controller logs a warning on mismatch, never fatal.
- CRD regenerated (`config/crd/bases` + chart copy), deepcopy regenerated.

## #41 — recipient roles + `git-secret-seal recipients` (`670c002`)

- Roles `human` / `controller` / `recovery` / `deprecated`, recorded in the
  `git-secret.opscalehub.io/recipient-roles` annotation (`<fp>:<role>`,
  comma-separated). Convention only — the controller never reads it.
- `git-secret-seal recipients list|add|remove`:
  - `list -f FILE` — fingerprint + role from `spec.recipients`
  - `add FPR -f FILE [--role R]` — rewrap to the extended set, record the role
  - `remove FPR -f FILE [--force]` — rewrap to the reduced set; refuses to drop
    the last recipient, or the last `recovery` one, without `--force`
  - no value is ever re-encrypted (`sealer.Rewrap`)
- `docs/security/recipient-lifecycle.md` — role table, workflow table, key
  expiry, and the historical-ciphertext property: removing a recipient does not
  undo their access to versions already in Git history; a compromised key needs
  value rotation, not just a rewrap.

## Not in this PR

Admission-webhook enforcement of `spec.recipients` (deferred, noted in
threat-model open items). Everything else in the backlog: #43 multi-cluster, #44
positioning, #45 gpg-default nudge, #46 sealing console, #47 cluster keyring, #48
final docs/landing-page gate.

## Verification

`go build ./... && go vet ./... && go test ./...` green locally. Tests added in
`api/v1alpha1`, `internal/sealer`, `internal/gpgutil`, `internal/controller`,
`cmd/git-secret-seal`.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT
