### PR TITLE
Positioning + gpg-backend guidance: repo thesis, multi-cluster note, init nudge (#43, #44, #45)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,51 @@
 # Git Secret Manager (`git-secret`)
 
-`git-secret` is a single-binary Git plugin that transparently encrypts sensitive files in a repository. You keep working with plaintext in your working tree; the installed git hooks make sure only ciphertext ever reaches your commit history.
+**A recoverable, Git-native cryptographic control plane for Kubernetes secrets.**
+
+The encrypted Git repository is the durable source of truth. Decryption is
+multi-recipient, auditable, and Kubernetes-native — and no single cluster,
+controller, or key is a single point of catastrophic recovery failure. It is also
+a plain single-binary Git plugin: transparent file encryption via git hooks, with
+plaintext only ever in your working tree, never in commit history.
+
+### Design goals
+
+1. No single controller key is a single point of unrecoverable failure.
+2. Losing Kubernetes does not lose the secrets.
+3. Git history stays a useful, durable encrypted record.
+4. Multiple humans and services decrypt independently.
+5. Kubernetes receives plaintext only at the final reconcile boundary.
+6. The controller is a *consumer* of the encrypted source, not its owner.
+7. Metadata is observable; plaintext never is.
+8. Recovery is possible entirely outside the cluster.
+9. Recipient identity is an explicit GPG fingerprint.
+10. Still fully useful with no Kubernetes at all (the CLI + `gpg` backend).
+
+### What it is not
+
+Not Vault, not a hosted secret manager, not a password manager, not a GPG
+replacement, not an identity provider — and not coupled to ESO, ArgoCD, or any
+one Git host.
+
+### Compared to
+
+| | `git-secret` | Bitnami sealed-secrets | SOPS | Vault |
+|---|---|---|---|---|
+| Ciphertext lives in Git | yes | yes | yes | no (external store) |
+| Survives loss of the cluster/controller key | **yes** (multi-recipient) | no (single keypair) | yes | n/a |
+| Kubernetes-native reconcile | yes (CRD + controller) | yes | via operator | via ESO/agent |
+| Useful with no Kubernetes | yes (CLI) | no | yes | no |
+| External service to operate | no | no | no | yes |
+
+See [docs/security/design-rationale.md](docs/security/design-rationale.md) for how
+the architecture got here.
 
 ## Features
 
 - **Transparent encryption**: git hooks (`pre-commit`, `post-checkout`, `post-merge`, `pre-push`) encrypt/decrypt automatically as you commit, checkout, merge, and push — no manual encrypt/decrypt step in the common case.
 - **Modern AEAD crypto**: XChaCha20-Poly1305 by default (AES-256-GCM available) does the actual file encryption either way — GPG is never in that path, so `file`/`env` need no GPG dependency at all.
 - **Config-driven**: glob `patterns` in a committed `.repo-enc.yml` decide which files are in scope; everything else is left untouched.
-- **Pluggable key backends**: `file` (a local, gitignored key file), `env` (an environment variable), or `gpg` (wraps the key to one or more existing GPG identities — safe to commit, no out-of-band key transfer needed). The `Backend` interface makes adding KMS backends straightforward too.
+- **Pluggable key backends**: `gpg` (wraps the key to one or more existing GPG identities — safe to commit, no out-of-band transfer, and the only backend that works with automated consumers or survives the loss of a single key — **recommended**), `file` (a local, gitignored key file — quick start, local/solo only), or `env` (an environment variable). The `Backend` interface makes adding KMS backends straightforward too.
 - **Safety net**: `verify` and the `pre-push` hook refuse to let plaintext that slipped past `pre-commit` (e.g. via `--no-verify`) reach a remote.
 - **Cross-platform**: pure Go, no runtime dependencies beyond `git` itself (`gpg` is an optional extra, only needed if you choose that backend). Installed hooks ship as both POSIX shell and PowerShell scripts.
 
@@ -40,15 +78,31 @@ Once `git-secret` is on your `PATH`, `git secret <command>` works as a git subco
 
 ```bash
 cd your-repo
-git secret init                 # writes .repo-enc.yml, generates a key, installs hooks
-git add .repo-enc.yml .gitignore
+
+# Recommended for any team, and required for Kubernetes/CI: the gpg backend,
+# with every human AND every service that needs access as its own recipient.
+git secret init --key-backend gpg \
+  --gpg-recipient <your-fingerprint> --gpg-recipient <teammate-fingerprint>
+git add .repo-enc.yml .repo-enc/key.gpg .gitignore
 git commit -m "chore: configure repo-enc"
 ```
 
+**Which backend?** `gpg` (above) is the only one that works with
+`git-secret-controller` or any automated consumer, and the only one where losing
+one key doesn't threaten recoverability — its wrapped key is safe to commit, no
+out-of-band key transfer. The `file` backend (`git secret init` with no
+`--key-backend`) is a quick local/solo on-ramp, but its key never enters git, so
+adopting Kubernetes or CI later forces a full re-seal. Start on `gpg` unless you
+are certain automation will never be in scope.
+
+```bash
+git secret init                 # 'file' backend: quick start, local/solo only
+```
+
 `.repo-enc.yml` must be committed — it's how a teammate's clone knows which
-patterns to encrypt/decrypt. The generated key must **not** be committed
-(`init` already gitignores it for the `file` backend); share it with
-collaborators out-of-band instead.
+patterns to encrypt/decrypt. For the `file` backend the generated key must
+**not** be committed (`init` gitignores it); share it out-of-band. For `gpg`,
+`.repo-enc/key.gpg` **is** committed and no key transfer is needed.
 
 By default `init` seeds `.repo-enc.yml` with the pattern `secrets/**`. Pass your own patterns instead:
 
@@ -309,6 +363,8 @@ A container image and Helm chart ship on every tagged release
   controller loss, cluster loss, key loss, and key compromise.
 - [Recipient & key lifecycle](docs/security/recipient-lifecycle.md) — roles,
   rotation workflows, and what removing a recipient does and doesn't undo.
+- [Multi-cluster operation](docs/architecture/multi-cluster.md) — one encrypted
+  repo, per-cluster controller identities, no central store.
 - [Reporting a vulnerability](SECURITY.md).
 
 The core property: the encrypted repository is the durable source of truth, and

--- a/docs/architecture/multi-cluster.md
+++ b/docs/architecture/multi-cluster.md
@@ -1,0 +1,77 @@
+# Multi-cluster operation
+
+Because a `GitSecret` carries its ciphertext inline and the content key is
+GPG-wrapped to N independent recipients, "another cluster consuming the same
+secret" is just "add that cluster's controller fingerprint as a recipient." No
+shared secret store, no central authority, no repo access from the cluster.
+
+This is a design note, not new code — the primitives (`sealer.Rewrap`, recipient
+roles, `git-secret-seal recipients`) already exist. It prescribes how to use them.
+
+## Recommended topology
+
+```
+                        Encrypted Git repo
+                       /       |         \
+                      /        |          \
+             Cluster A    Cluster B     Recovery
+             controller   controller    (offline human key,
+             fingerprint  fingerprint    never a controller)
+                 |            |
+              Secret       Secret
+```
+
+- **Each cluster's controller has its own GPG identity.** Never share one keypair
+  across clusters — then revoking or rebuilding one cluster is a
+  `git-secret-seal recipients remove` that does not touch the others.
+- **Do not wrap every object to every cluster.** A prod-only secret is wrapped to
+  the prod cluster's controller (+ recovery), not to staging/dev. This keeps the
+  blast radius of a compromised cluster controller to exactly the objects that
+  cluster was meant to consume.
+- **The recovery recipient is cluster-independent** — offline, in every
+  production object, so no combination of cluster losses is unrecoverable.
+
+## Environment boundaries
+
+Represent prod / staging / dev as distinct recipient sets, applied at seal time:
+
+```
+git-secret-seal recipients list -f gitsecret.yaml
+# prod:  <prod-controller>:controller  <recovery>:recovery  <oncall-human>:human
+# stage: <stage-controller>:controller <recovery>:recovery
+```
+
+A future `git-secret-seal` policy/profile file could enforce "objects under
+`envs/prod/**` must be sealed to exactly this set" — tracked with #47 (keyring).
+
+## Runbooks
+
+### Add a cluster
+
+1. Generate the new controller's identity; import its public key locally.
+2. `git-secret-seal recipients add <new-controller-fpr> -f obj.yaml --role controller`
+   for every object that cluster should consume.
+3. Commit; point the new cluster's ArgoCD at the repo; deploy its controller.
+
+### Replace / decommission a cluster
+
+1. `git-secret-seal recipients remove <old-controller-fpr> -f obj.yaml` for every
+   object.
+2. Commit. The old controller can still decrypt versions already in Git history
+   (see [recipient-lifecycle.md](../security/recipient-lifecycle.md)) — if the
+   old cluster is considered compromised rather than merely retired, treat it as
+   the compromise case (rotate the secret values).
+
+### Compromised cluster controller
+
+Blast radius = exactly the objects wrapped to that controller's fingerprint.
+Rotate those secret values at source, re-seal, and remove the compromised
+fingerprint. Other clusters' objects are unaffected because they were never
+wrapped to that key.
+
+## Open questions (not blocking)
+
+- A `git-secret-seal` policy file for enforcing per-environment recipient sets.
+- Whether the controller should expose, in `status`, which *other* clusters'
+  fingerprints an object is wrapped to (it can already list the fingerprints; it
+  cannot label them by cluster without the keyring in #47).

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -79,7 +79,7 @@ Notation: **L** = availability/recovery, **C** = confidentiality, **I** = integr
 | T6 | Operator workstation compromised | C | **Out of scope to prevent.** Blast radius = everything that workstation's keyring can decrypt. Mitigation is operational: per-person keys, hardware-backed keys, offline recovery key not on any workstation. |
 | T7 | Plaintext leak via logs / Events / `status` / metrics | C | **Invariant (I3), regression-tested.** `TestUnseal_ErrorDoesNotLeakPlaintext` asserts a tampered-envelope failure never echoes the plaintext into the returned error (which the controller copies into `.status`). |
 | T8 | Malicious cluster administrator | C | **Out of scope.** Anyone who can `kubectl get secret -o yaml` wins without touching `git-secret`. |
-| T9 | Compromised controller pod | C | Blast radius = `GitSecret`s wrapped to the controller key. Mitigation: don't wrap every object to every controller (per-cluster/per-env recipients, #43); `runAsNonRoot`, read-only rootfs, minimal RBAC. |
+| T9 | Compromised controller pod | C | Blast radius = `GitSecret`s wrapped to the controller key. Mitigation: don't wrap every object to every controller — per-cluster / per-env recipient sets ([multi-cluster.md](../architecture/multi-cluster.md)); `runAsNonRoot`, read-only rootfs, minimal RBAC. |
 | T10 | Rollback / history-rewrite of a `GitSecret` in Git | I | An old object version re-applied re-installs old secret values silently. Provenance (which Git revision produced this Secret) is not surfaced — future work. |
 | T11 | Recipient substitution — object sealed to an attacker key alongside the real ones | C | **Partial.** `spec.recipients` now lists the fingerprints on the object, so adding one is a visible one-line diff in review; `sealer.VerifyRecipients` cross-checks the count against the blob and the controller logs a warning on mismatch. Not yet enforced by admission (#41). |
 | T12 | Pre-existing target `Secret` silently adopted & cleared | I | **Handled.** A colliding `Secret` this `GitSecret` does not own is left untouched and a `TargetConflict` Ready=False condition is set, unless the operator opts in with `spec.target.adopt`. Tests `TestReconcile_DoesNotClobberUnownedSecret` / `_AdoptsUnownedSecretWhenOptedIn`. |
@@ -134,10 +134,11 @@ regression regardless of the feature it enables.
 
 ## 6. Open items feeding this model
 
-#43 (multi-cluster blast radius) · #47 (keyring / pubkey discovery) · admission
-enforcement of `spec.recipients` (deferred from #41).
+#47 (keyring / pubkey discovery) · admission enforcement of `spec.recipients`
+(deferred from #41) · provenance / which-Git-revision-produced-this-Secret (T10).
 
 Closed: #38 (this doc) · #39 (DR runbooks + tests) · #40 (`spec.recipients` +
 status mirror + `VerifyRecipients`) · #41 (recipient roles + `git-secret-seal
 recipients` + [lifecycle doc](recipient-lifecycle.md)) · #42 (controller adoption
-guard, input bounds, status-leak regression test).
+guard, input bounds, status-leak regression test) · #43
+([multi-cluster.md](../architecture/multi-cluster.md)).

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -80,6 +80,9 @@ func TestInitCreatesConfigKeyAndHooks(t *testing.T) {
 	if !result.GeneratedKey {
 		t.Errorf("expected Init to generate a key on first run")
 	}
+	if !result.BackendDefaultedToFile {
+		t.Errorf("expected BackendDefaultedToFile when no --key-backend was given")
+	}
 	if _, err := os.Stat(result.ConfigPath); err != nil {
 		t.Errorf("config file missing: %v", err)
 	}

--- a/internal/cli/gpg_workflow_test.go
+++ b/internal/cli/gpg_workflow_test.go
@@ -134,6 +134,9 @@ func TestInitWithGPGBackend(t *testing.T) {
 	if !result.KeyIsCommittable {
 		t.Fatalf("expected KeyIsCommittable for gpg backend")
 	}
+	if result.BackendDefaultedToFile {
+		t.Fatalf("BackendDefaultedToFile must be false when --key-backend gpg was given")
+	}
 
 	// Unlike the file backend, the wrapped key must NOT be gitignored.
 	gitignore, _ := os.ReadFile(filepath.Join(root, ".gitignore"))

--- a/internal/cli/init.go
+++ b/internal/cli/init.go
@@ -36,6 +36,12 @@ type InitResult struct {
 	KeyIsCommittable bool
 	KeySource        string
 	HooksInstalled   []string
+	// BackendDefaultedToFile is true when no --key-backend was given and
+	// the repo was set up on "file". The caller uses it to print a nudge:
+	// "file" is a fine local on-ramp but is structurally incompatible with
+	// git-secret-controller or any automated consumer (its key never
+	// enters git), and switching later means re-sealing everything.
+	BackendDefaultedToFile bool
 }
 
 // Init bootstraps repo-enc in the current repository: writes a config
@@ -76,7 +82,12 @@ func Init(opts InitOptions) (*InitResult, error) {
 		return nil, err
 	}
 
-	result := &InitResult{ConfigPath: cfgPath, KeySource: cfg.KeySource, KeyIsCommittable: cfg.KeyBackend == "gpg"}
+	result := &InitResult{
+		ConfigPath:             cfgPath,
+		KeySource:              cfg.KeySource,
+		KeyIsCommittable:       cfg.KeyBackend == "gpg",
+		BackendDefaultedToFile: opts.KeyBackend == "" && cfg.KeyBackend == "file",
+	}
 
 	if _, err := backend.Get(root, cfg.KeySource); errors.Is(err, keybackend.ErrKeyNotFound) {
 		if cfg.KeyBackend == "gpg" {

--- a/main.go
+++ b/main.go
@@ -230,6 +230,16 @@ func cmdInit(args []string) int {
 		}
 	}
 	fmt.Printf("Installed hooks: %s\n", strings.Join(result.HooksInstalled, ", "))
+	if result.BackendDefaultedToFile {
+		fmt.Println()
+		fmt.Println("Note: using the 'file' key backend (the default). Fine for local or")
+		fmt.Println("solo use, but its key never enters git, so git-secret-controller and")
+		fmt.Println("any automated consumer cannot decrypt a 'file'-backend repo — switching")
+		fmt.Println("later means re-sealing every secret. If Kubernetes or CI is a")
+		fmt.Println("possibility, re-run in a fresh repo with --key-backend gpg (multiple")
+		fmt.Println("recipients: every human and every service that needs access).")
+		fmt.Println("See docs/security/recipient-lifecycle.md.")
+	}
 	return exitOK
 }
 


### PR DESCRIPTION
Positioning + `gpg`-backend guidance batch of the backlog reset (#43, #44, #45).
Mostly docs; one small CLI behaviour addition (an `init` nudge).

## #45 — nudge away from the `file` backend at init (`5e899a6`)

`git secret init` with no `--key-backend` sets up the `file` backend, whose key
never enters git — so `git-secret-controller` and any automated consumer cannot
decrypt the repo, and switching later means re-sealing everything (this bit a real
production adoption). Now `init` prints a note explaining that when it defaults to
`file`. New `InitResult.BackendDefaultedToFile` drives it; verified against a real
`git secret init` run.

README Quick Start now leads with:

```
git secret init --key-backend gpg \
  --gpg-recipient <you> --gpg-recipient <teammate>
```

and a "which backend?" paragraph. The `file` one-liner is kept, clearly marked
local/solo.

## #44 — repositioning

README reframed from "a Git plugin that encrypts files" to **"a recoverable,
Git-native cryptographic control plane for Kubernetes secrets"** — with the 10
design goals, a "what it is not" list, and a comparison table against
sealed-secrets / SOPS / Vault.

## #43 — multi-cluster design note

`docs/architecture/multi-cluster.md`: one encrypted repo, a distinct controller
GPG identity per cluster, per-environment recipient sets so a compromised cluster
controller's blast radius is exactly the objects it was meant to consume.
Add/replace/compromise runbooks built on `git-secret-seal recipients`. Design
note only — the primitives already exist.

## Verification

`go build ./... && go vet ./... && go test ./...` green (one transient
gpg-agent flake on first run, clean on `-count=1` re-run). Test assertions for
`BackendDefaultedToFile` added in `internal/cli`.

## Remaining backlog

#47 cluster keyring (controller publishes its pubkey; `git-secret-seal --keyring`)
· #46 sealing console (feasibility) · #48 final docs + landing-page sweep gate.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT
