### PR TITLE
Cluster keyring: --print-public-key, git-secret-seal --keyring (#47)

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,8 @@ A container image and Helm chart ship on every tagged release
   rotation workflows, and what removing a recipient does and doesn't undo.
 - [Multi-cluster operation](docs/architecture/multi-cluster.md) — one encrypted
   repo, per-cluster controller identities, no central store.
+- [Cluster keyring](docs/architecture/keyring.md) — `--print-public-key`,
+  `git-secret-seal --keyring`, per-environment recipient sets.
 - [Reporting a vulnerability](SECURITY.md).
 
 The core property: the encrypted repository is the durable source of truth, and

--- a/cmd/git-secret-controller/main.go
+++ b/cmd/git-secret-controller/main.go
@@ -45,6 +45,7 @@ func run(args []string, environ []string) int {
 	healthAddr := fs.String("health-probe-bind-address", ":8081", "address the liveness/readiness probe endpoint binds to (env HEALTH_PROBE_BIND_ADDRESS)")
 	leaderElect := fs.Bool("leader-elect", false, "enable leader election so only one replica reconciles at a time (env LEADER_ELECT)")
 	gpgPrivateKeyFile := fs.String("gpg-private-key-file", "", "path to this controller's armored GPG private key, imported at startup (env GPG_PRIVATE_KEY_FILE)")
+	printPublicKey := fs.Bool("print-public-key", false, "import the key, print its fingerprint and armored PUBLIC key to stdout, and exit (for handing to whoever seals GitSecrets to this controller)")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
@@ -100,6 +101,22 @@ func run(args []string, environ []string) int {
 		gpgKey[i] = 0
 	}
 	gpgKey = nil
+
+	if *printPublicKey {
+		keys, err := gpgutil.ListSecretKeys()
+		if err != nil || len(keys) == 0 {
+			setupLog.Error(err, "list imported secret key")
+			return exitError
+		}
+		pub, err := gpgutil.ExportPublicKey(keys[0].Fingerprint)
+		if err != nil {
+			setupLog.Error(err, "export public key")
+			return exitError
+		}
+		fmt.Println(keys[0].Fingerprint)
+		os.Stdout.Write(pub)
+		return 0
+	}
 
 	mgr, err := ctrl.NewManager(ctrl.GetConfigOrDie(), ctrl.Options{
 		Scheme: scheme,

--- a/cmd/git-secret-controller/main_test.go
+++ b/cmd/git-secret-controller/main_test.go
@@ -18,8 +18,12 @@ func TestPrintPublicKey(t *testing.T) {
 	if !gpgutil.Available() {
 		t.Skip("gpg not installed")
 	}
-	if runtime.GOOS == "windows" {
-		t.Skip("gpg-agent unreliable on windows CI runners")
+	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
+		// run() imports a secret key into a fresh GNUPGHOME, which needs a
+		// working gpg-agent -- not reliably spawnable on the hosted
+		// macOS/Windows runners (the sealer/gpgutil suites skip these for
+		// the same reason). Linux CI + local dev cover this path.
+		t.Skipf("gpg-agent unreliable on %s CI runners", runtime.GOOS)
 	}
 
 	home, err := os.MkdirTemp("/tmp", "gsc-test-")
@@ -42,23 +46,6 @@ func TestPrintPublicKey(t *testing.T) {
 	keyPath := t.TempDir() + "/key.asc"
 	if err := os.WriteFile(keyPath, priv, 0o600); err != nil {
 		t.Fatal(err)
-	}
-
-	// run() imports the secret key into a fresh GNUPGHOME, which needs a
-	// working gpg-agent -- not reliably available on hosted CI runners
-	// (macOS/Windows especially). Preflight the exact same operation and
-	// skip rather than fail when the agent can't be reached, matching how
-	// the sealer/gpgutil suites guard their gpg-dependent tests.
-	pre, err := os.MkdirTemp("/tmp", "gsc-preflight-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() { os.RemoveAll(pre) })
-	imp := exec.Command("gpg", "--batch", "--import")
-	imp.Env = append(os.Environ(), "GNUPGHOME="+pre)
-	imp.Stdin = bytes.NewReader(priv)
-	if out, err := imp.CombinedOutput(); err != nil || bytes.Contains(out, []byte("No agent running")) {
-		t.Skipf("gpg secret-key import not usable in this environment, skipping: %v: %s", err, out)
 	}
 
 	// Capture stdout.

--- a/cmd/git-secret-controller/main_test.go
+++ b/cmd/git-secret-controller/main_test.go
@@ -44,6 +44,23 @@ func TestPrintPublicKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// run() imports the secret key into a fresh GNUPGHOME, which needs a
+	// working gpg-agent -- not reliably available on hosted CI runners
+	// (macOS/Windows especially). Preflight the exact same operation and
+	// skip rather than fail when the agent can't be reached, matching how
+	// the sealer/gpgutil suites guard their gpg-dependent tests.
+	pre, err := os.MkdirTemp("/tmp", "gsc-preflight-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(pre) })
+	imp := exec.Command("gpg", "--batch", "--import")
+	imp.Env = append(os.Environ(), "GNUPGHOME="+pre)
+	imp.Stdin = bytes.NewReader(priv)
+	if out, err := imp.CombinedOutput(); err != nil || bytes.Contains(out, []byte("No agent running")) {
+		t.Skipf("gpg secret-key import not usable in this environment, skipping: %v: %s", err, out)
+	}
+
 	// Capture stdout.
 	r, w, _ := os.Pipe()
 	orig := os.Stdout

--- a/cmd/git-secret-controller/main_test.go
+++ b/cmd/git-secret-controller/main_test.go
@@ -1,0 +1,72 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/OpScaleHub/git-secret/internal/gpgutil"
+)
+
+// TestPrintPublicKey exercises the --print-public-key path, which imports
+// the configured private key and prints only its fingerprint + armored
+// PUBLIC key, without ever contacting a cluster.
+func TestPrintPublicKey(t *testing.T) {
+	if !gpgutil.Available() {
+		t.Skip("gpg not installed")
+	}
+	if runtime.GOOS == "windows" {
+		t.Skip("gpg-agent unreliable on windows CI runners")
+	}
+
+	home, err := os.MkdirTemp("/tmp", "gsc-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { os.RemoveAll(home) })
+
+	gen := exec.Command("gpg", "--batch", "--passphrase", "", "--quick-generate-key", "ctrl test <ctrl-test@example.invalid>", "default", "default", "never")
+	gen.Env = append(os.Environ(), "GNUPGHOME="+home)
+	if out, err := gen.CombinedOutput(); err != nil {
+		t.Skipf("gpg key generation not usable here: %v: %s", err, out)
+	}
+	exp := exec.Command("gpg", "--batch", "--armor", "--export-secret-keys")
+	exp.Env = append(os.Environ(), "GNUPGHOME="+home)
+	priv, err := exp.Output()
+	if err != nil {
+		t.Fatalf("export secret key: %v", err)
+	}
+	keyPath := t.TempDir() + "/key.asc"
+	if err := os.WriteFile(keyPath, priv, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Capture stdout.
+	r, w, _ := os.Pipe()
+	orig := os.Stdout
+	os.Stdout = w
+	code := run([]string{"--gpg-private-key-file", keyPath, "--print-public-key"}, os.Environ())
+	w.Close()
+	os.Stdout = orig
+	var buf bytes.Buffer
+	buf.ReadFrom(r)
+
+	if code != 0 {
+		t.Fatalf("run() = %d", code)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "BEGIN PGP PUBLIC KEY BLOCK") {
+		t.Fatalf("output has no armored public key:\n%s", out)
+	}
+	if strings.Contains(out, "PRIVATE KEY") {
+		t.Fatal("output leaked private key material")
+	}
+	// First line is the fingerprint (40 hex).
+	first := strings.SplitN(strings.TrimSpace(out), "\n", 2)[0]
+	if len(first) != 40 {
+		t.Fatalf("first line is not a 40-hex fingerprint: %q", first)
+	}
+}

--- a/cmd/git-secret-seal/keyring.go
+++ b/cmd/git-secret-seal/keyring.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/OpScaleHub/git-secret/api/v1alpha1"
+	"github.com/OpScaleHub/git-secret/internal/gpgutil"
+)
+
+// keyringFile is the on-disk format for --keyring: a plain list of the
+// recipients a repo/cluster normally seals to, so `git-secret-seal` can
+// resolve them instead of the caller retyping every fingerprint. It is not
+// secret (public keys / fingerprints only) and is meant to be committed
+// alongside the GitSecrets it applies to.
+//
+//	recipients:
+//	  - fingerprint: AAAA...   # 40 or 64 hex
+//	    role: controller       # human|controller|recovery|deprecated (optional)
+//	  - fingerprint: BBBB...
+//	    role: recovery
+type keyringFile struct {
+	Recipients []struct {
+		Fingerprint string `json:"fingerprint"`
+		Role        string `json:"role,omitempty"`
+	} `json:"recipients"`
+}
+
+// loadKeyring reads path and returns its fingerprints (validated) and any
+// roles keyed by upper-case fingerprint.
+func loadKeyring(path string) (fingerprints []string, roles map[string]v1alpha1.RecipientRole, err error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, fmt.Errorf("read keyring %s: %w", path, err)
+	}
+	var kr keyringFile
+	if err := sigsyaml.Unmarshal(raw, &kr); err != nil {
+		return nil, nil, fmt.Errorf("parse keyring %s: %w", path, err)
+	}
+	if len(kr.Recipients) == 0 {
+		return nil, nil, fmt.Errorf("keyring %s lists no recipients", path)
+	}
+	roles = map[string]v1alpha1.RecipientRole{}
+	seen := map[string]bool{}
+	for i, r := range kr.Recipients {
+		if !gpgutil.ValidFingerprint(r.Fingerprint) {
+			return nil, nil, fmt.Errorf("keyring %s: recipients[%d].fingerprint %q is not a full GPG fingerprint", path, i, r.Fingerprint)
+		}
+		key := upperFP(r.Fingerprint)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		fingerprints = append(fingerprints, r.Fingerprint)
+		if r.Role != "" {
+			role := v1alpha1.RecipientRole(r.Role)
+			if !v1alpha1.ValidRecipientRole(role) {
+				return nil, nil, fmt.Errorf("keyring %s: recipients[%d].role %q is not valid (human|controller|recovery|deprecated)", path, i, r.Role)
+			}
+			roles[key] = role
+		}
+	}
+	return fingerprints, roles, nil
+}
+
+func upperFP(s string) string {
+	b := []byte(s)
+	for i, c := range b {
+		if c >= 'a' && c <= 'f' {
+			b[i] = c - 32
+		}
+	}
+	return string(b)
+}

--- a/cmd/git-secret-seal/keyring_test.go
+++ b/cmd/git-secret-seal/keyring_test.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/OpScaleHub/git-secret/api/v1alpha1"
+	"github.com/OpScaleHub/git-secret/internal/sealer"
+)
+
+func TestRun_KeyringResolvesRecipientsAndRoles(t *testing.T) {
+	ctrlHome := shortTempDir(t)
+	ctrlFpr := genTestKey(t, ctrlHome)
+	recHome := shortTempDir(t)
+	recFpr := genTestKey(t, recHome)
+
+	// Seal runs in the controller's keyring; it needs the recovery pubkey.
+	importPublicKeyCLI(t, ctrlHome, exportPublicKeyCLI(t, recHome, recFpr))
+	t.Setenv("GNUPGHOME", ctrlHome)
+
+	keyring := "recipients:\n" +
+		"  - fingerprint: " + ctrlFpr + "\n" +
+		"    role: controller\n" +
+		"  - fingerprint: " + recFpr + "\n" +
+		"    role: recovery\n"
+	krPath := t.TempDir() + "/keyring.yaml"
+	if err := os.WriteFile(krPath, []byte(keyring), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out, errb bytes.Buffer
+	code := run([]string{
+		"--namespace", "ns", "--name", "obj",
+		"--keyring", krPath,
+		"--from-literal", "K=v",
+	}, &out, &errb)
+	if code != exitOK {
+		t.Fatalf("run() = %d: %s", code, errb.String())
+	}
+
+	var gs v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal(out.Bytes(), &gs); err != nil {
+		t.Fatal(err)
+	}
+	if len(gs.Spec.Recipients) != 2 {
+		t.Fatalf("recipients = %v, want 2 from the keyring", gs.Spec.Recipients)
+	}
+	roles := v1alpha1.ParseRecipientRoles(gs.Annotations)
+	if roles[upperFP(ctrlFpr)] != v1alpha1.RoleController || roles[upperFP(recFpr)] != v1alpha1.RoleRecovery {
+		t.Fatalf("roles not recorded from keyring: %v", gs.Annotations)
+	}
+
+	// Both identities can decrypt.
+	for _, home := range []string{ctrlHome, recHome} {
+		t.Setenv("GNUPGHOME", home)
+		if _, err := sealer.Unseal("ns", "obj", gs.Spec); err != nil {
+			t.Fatalf("unseal with %s failed: %v", home, err)
+		}
+	}
+}
+
+func TestRun_KeyringRejectsBadFingerprint(t *testing.T) {
+	krPath := t.TempDir() + "/keyring.yaml"
+	if err := os.WriteFile(krPath, []byte("recipients:\n  - fingerprint: NOTAFINGERPRINT\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var out, errb bytes.Buffer
+	code := run([]string{"--namespace", "ns", "--name", "o", "--keyring", krPath, "--from-literal", "K=v"}, &out, &errb)
+	if code == exitOK {
+		t.Fatal("expected failure on a malformed keyring fingerprint")
+	}
+	if !strings.Contains(errb.String(), "fingerprint") {
+		t.Fatalf("unexpected error: %s", errb.String())
+	}
+}

--- a/cmd/git-secret-seal/main.go
+++ b/cmd/git-secret-seal/main.go
@@ -49,11 +49,17 @@ Usage:
                                 target Secret) will live in. Required.
   --name NAME                   Name of the GitSecret object. Required.
   --recipient FPR               Full 40/64-hex GPG fingerprint to encrypt to.
-                                Repeatable; at least one required. Passing
-                                every current human + controller recipient
-                                here, not just the controller's own key, is
-                                what avoids sealed-secrets' single-keypair
-                                DR weakness -- see docs/security/design-rationale.md.
+                                Repeatable. At least one recipient is required
+                                (via --recipient or --keyring). Passing every
+                                current human + controller recipient, not just
+                                the controller's own key, is what avoids
+                                sealed-secrets' single-keypair DR weakness --
+                                see docs/security/design-rationale.md.
+  --keyring FILE                A keyring file (recipients: [{fingerprint,
+                                role}]) whose fingerprints are added to the
+                                recipient set and whose roles are recorded on
+                                the manifest -- so you don't retype the same
+                                cluster/repo recipients every time.
   --target-name NAME             Name of the Secret the controller creates.
                                 Defaults to --name.
   --target-type TYPE             Kubernetes Secret type. Defaults to Opaque.
@@ -126,6 +132,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 	fromSecretFile := fs.String("from-secret-file", "", "path to an existing Secret manifest to seal (- for stdin)")
 	fromEnvFile := fs.String("from-env-file", "", "path to a KEY=VALUE file to seal")
 	rewrapFile := fs.String("rewrap", "", "path to an existing GitSecret manifest to rewrap to a new --recipient list, without re-encrypting its values (- for stdin)")
+	keyringFile := fs.String("keyring", "", "path to a keyring file listing recipients (fingerprint + optional role); used in addition to any --recipient flags")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	var literals stringSlice
 	var recipients stringSlice
@@ -197,8 +204,28 @@ func run(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "error: --namespace and --name are required (or must be derivable from -f's Secret metadata)")
 		return exitUsage
 	}
+
+	var keyringRoles map[string]v1alpha1.RecipientRole
+	if *keyringFile != "" {
+		krFprs, krRoles, err := loadKeyring(*keyringFile)
+		if err != nil {
+			fmt.Fprintln(stderr, "error:", err)
+			return exitError
+		}
+		seen := map[string]bool{}
+		for _, r := range recipients {
+			seen[upperFP(r)] = true
+		}
+		for _, fp := range krFprs {
+			if !seen[upperFP(fp)] {
+				recipients = append(recipients, fp)
+			}
+		}
+		keyringRoles = krRoles
+	}
+
 	if len(recipients) == 0 {
-		fmt.Fprintln(stderr, "error: at least one --recipient is required")
+		fmt.Fprintln(stderr, "error: at least one recipient is required (--recipient or --keyring)")
 		return exitUsage
 	}
 	if len(data) == 0 {
@@ -228,6 +255,13 @@ func run(args []string, stdout, stderr io.Writer) int {
 	gs.Name = nm
 	gs.Namespace = ns
 	gs.Spec = spec
+
+	// Carry any roles the keyring assigned onto the object, so the sealed
+	// manifest records which recipient is the controller, which is the
+	// offline recovery key, etc.
+	if roleStr := v1alpha1.FormatRecipientRoles(keyringRoles); roleStr != "" {
+		gs.Annotations = map[string]string{v1alpha1.RecipientRolesAnnotation: roleStr}
+	}
 
 	// sigs.k8s.io/yaml, not gopkg.in/yaml.v3: gs's fields carry only
 	// `json:"..."` tags (the Kubernetes API convention), which yaml.v3

--- a/docs/architecture/keyring.md
+++ b/docs/architecture/keyring.md
@@ -1,0 +1,68 @@
+# Cluster keyring & public-key discovery
+
+To seal a `GitSecret` *to a cluster* you need the public keys to seal to: the
+cluster's `git-secret-controller` key, plus the humans and the offline recovery
+key. This is how to make that set discoverable instead of a list of fingerprints
+passed around by hand.
+
+## The controller's own public key
+
+The controller can print its public key without contacting a cluster:
+
+```
+git-secret-controller --gpg-private-key-file controller-key.asc --print-public-key
+```
+
+It imports the key exactly as it does at startup, then prints the **fingerprint**
+on the first line followed by the **armored public key**, and exits. Public keys
+are not secret; nothing sensitive is exposed.
+
+Distribute it however suits you — commit it to the repo, drop it in a `ConfigMap`
+(`kubectl create configmap git-secret-controller-pubkey --from-literal=...`), or
+publish it internally. A Helm hook/Job to create that `ConfigMap` automatically
+is a planned follow-up (#47).
+
+## The keyring file
+
+A plain, committable file listing the recipients a repo (or an environment)
+normally seals to:
+
+```yaml
+# keyring.yaml
+recipients:
+  - fingerprint: 1111111111111111111111111111111111111111
+    role: controller          # human | controller | recovery | deprecated
+  - fingerprint: 2222222222222222222222222222222222222222
+    role: recovery
+  - fingerprint: 3333333333333333333333333333333333333333
+    role: human
+```
+
+`git-secret-seal --keyring keyring.yaml` adds every listed fingerprint to the
+recipient set (in addition to any `--recipient` flags) and records the roles in
+the manifest's `git-secret.opscalehub.io/recipient-roles` annotation:
+
+```
+git-secret-seal --namespace prod --name app-secrets \
+  --keyring envs/prod/keyring.yaml \
+  --from-env-file app.env > gitsecret.yaml
+```
+
+One keyring per environment (`envs/prod/keyring.yaml`,
+`envs/staging/keyring.yaml`) is the recommended layout — it makes the
+per-environment recipient boundary from
+[multi-cluster.md](multi-cluster.md) a reviewable file rather than tribal
+knowledge.
+
+The keyring holds fingerprints and roles only. Resolving `name -> fingerprint` or
+distributing the actual public key material (WKD, a keyserver, committed `.asc`
+files) is out of scope — the keyring assumes the sealing operator already has the
+public keys in their GPG keyring, the same precondition `--recipient` already has.
+
+## Not yet
+
+- `--keyring` accepts a local file path only. Fetching a keyring (or the
+  controller's `/pubkey`) over HTTP is a follow-up, with its own trust questions.
+- A `git-secret-seal keyring add/verify` helper to build and check the file.
+- Admission-webhook enforcement that a `GitSecret` under `envs/prod/**` matches
+  the prod keyring.

--- a/docs/architecture/multi-cluster.md
+++ b/docs/architecture/multi-cluster.md
@@ -41,8 +41,11 @@ git-secret-seal recipients list -f gitsecret.yaml
 # stage: <stage-controller>:controller <recovery>:recovery
 ```
 
-A future `git-secret-seal` policy/profile file could enforce "objects under
-`envs/prod/**` must be sealed to exactly this set" — tracked with #47 (keyring).
+Keep one [keyring file](keyring.md) per environment
+(`envs/prod/keyring.yaml`, ...) and seal with `git-secret-seal --keyring
+envs/prod/keyring.yaml` so the recipient boundary is a reviewable file, not
+tribal knowledge. Admission enforcement that objects under `envs/prod/**` match
+the prod keyring is a planned follow-up.
 
 ## Runbooks
 
@@ -71,7 +74,6 @@ wrapped to that key.
 
 ## Open questions (not blocking)
 
-- A `git-secret-seal` policy file for enforcing per-environment recipient sets.
-- Whether the controller should expose, in `status`, which *other* clusters'
-  fingerprints an object is wrapped to (it can already list the fingerprints; it
-  cannot label them by cluster without the keyring in #47).
+- Admission enforcement of per-environment recipient sets against the keyring.
+- Whether the controller should label recipient fingerprints by cluster in
+  `status` (it lists them already; labelling needs the keyring).

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -134,11 +134,14 @@ regression regardless of the feature it enables.
 
 ## 6. Open items feeding this model
 
-#47 (keyring / pubkey discovery) · admission enforcement of `spec.recipients`
-(deferred from #41) · provenance / which-Git-revision-produced-this-Secret (T10).
+Admission enforcement of `spec.recipients` / per-environment keyrings (deferred
+from #41/#47) · keyring-over-HTTP + a Helm Job to publish the controller pubkey
+`ConfigMap` (deferred from #47) · provenance / which-Git-revision-produced-this-
+Secret (T10).
 
 Closed: #38 (this doc) · #39 (DR runbooks + tests) · #40 (`spec.recipients` +
 status mirror + `VerifyRecipients`) · #41 (recipient roles + `git-secret-seal
 recipients` + [lifecycle doc](recipient-lifecycle.md)) · #42 (controller adoption
 guard, input bounds, status-leak regression test) · #43
-([multi-cluster.md](../architecture/multi-cluster.md)).
+([multi-cluster.md](../architecture/multi-cluster.md)) · #47
+([keyring.md](../architecture/keyring.md): `--print-public-key`, `--keyring`).

--- a/internal/gpgutil/gpgutil.go
+++ b/internal/gpgutil/gpgutil.go
@@ -172,6 +172,24 @@ func ImportSecretKey(armored []byte) error {
 	return nil
 }
 
+// ExportPublicKey returns the ASCII-armored public key for fpr from the
+// current GNUPGHOME. Public keys are not secret -- this is used to hand a
+// controller's own public key to whoever needs to seal GitSecrets to it,
+// without exposing anything sensitive.
+func ExportPublicKey(fpr string) ([]byte, error) {
+	if !ValidFingerprint(fpr) {
+		return nil, fmt.Errorf("gpgutil: %q is not a full fingerprint", fpr)
+	}
+	out, err := run(nil, "--batch", "--armor", "--export", fpr)
+	if err != nil {
+		return nil, fmt.Errorf("gpgutil: export public key: %w", err)
+	}
+	if !bytes.Contains(out, []byte("BEGIN PGP PUBLIC KEY BLOCK")) {
+		return nil, fmt.Errorf("gpgutil: no public key found for %s", fpr)
+	}
+	return out, nil
+}
+
 // CountRecipients returns how many public-key recipients an armored GPG
 // message is encrypted to, counting its pubkey-enc packets. It does not
 // resolve them to fingerprints -- the packet carries a recipient's

--- a/internal/gpgutil/gpgutil_test.go
+++ b/internal/gpgutil/gpgutil_test.go
@@ -282,3 +282,25 @@ func TestCountRecipients(t *testing.T) {
 		t.Fatal("CountRecipients accepted garbage")
 	}
 }
+
+func TestExportPublicKey(t *testing.T) {
+	fpr := newTestKeyring(t, "Export <export@example.com>")
+
+	pub, err := ExportPublicKey(fpr)
+	if err != nil {
+		t.Fatalf("ExportPublicKey: %v", err)
+	}
+	if !bytes.Contains(pub, []byte("BEGIN PGP PUBLIC KEY BLOCK")) {
+		t.Fatalf("not an armored public key: %q", pub)
+	}
+	if bytes.Contains(pub, []byte("PRIVATE KEY")) {
+		t.Fatal("ExportPublicKey leaked private key material")
+	}
+
+	if _, err := ExportPublicKey("DEADBEEF"); err == nil {
+		t.Fatal("ExportPublicKey accepted a short key ID")
+	}
+	if _, err := ExportPublicKey("0000000000000000000000000000000000000000"); err == nil {
+		t.Fatal("ExportPublicKey returned success for an unknown fingerprint")
+	}
+}


### PR DESCRIPTION
Cluster keyring / recipient public-key discovery (#47). Makes the set of
recipient public keys discoverable instead of a list of fingerprints passed
around by hand.

## `gpgutil.ExportPublicKey(fpr)`

Armored public key from the current GNUPGHOME. Fingerprint-validated; asserts the
output is a public-key block (never leaks private material).

## `git-secret-controller --print-public-key`

Imports the configured private key exactly as it does at startup, prints the
**fingerprint** (first line) + **armored public key**, and exits. No cluster
contact, no new RBAC. Hand the output to whoever seals GitSecrets to this
controller — commit it, or `kubectl create configmap git-secret-controller-pubkey
--from-literal=...`.

## `git-secret-seal --keyring FILE`

A committable file listing the recipients a repo/environment normally seals to:

```yaml
recipients:
  - fingerprint: 1111...   # 40/64 hex
    role: controller       # human | controller | recovery | deprecated
  - fingerprint: 2222...
    role: recovery
```

`--keyring` adds every listed fingerprint to the recipient set (union with
`--recipient` flags) and records the roles in the
`git-secret.opscalehub.io/recipient-roles` annotation. One keyring per
environment (`envs/prod/keyring.yaml`) turns the per-cluster recipient boundary
from [multi-cluster.md] into a reviewable file. Every fingerprint is validated.

## Docs

`docs/architecture/keyring.md`; `multi-cluster.md` and `threat-model.md` updated.

## Deferred (noted in threat-model open items)

Keyring / `/pubkey` fetch over HTTP (has its own trust questions), a Helm Job to
publish the controller-pubkey ConfigMap automatically, and admission enforcement
that objects under `envs/prod/**` match the prod keyring.

## Verification

`go build ./... && go vet ./... && go test ./...` green. New tests in
`internal/gpgutil`, `cmd/git-secret-seal`, and `cmd/git-secret-controller` (first
test file for that package).

## Remaining backlog

#46 sealing console (feasibility) · #48 final docs + landing-page sweep gate.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT
