### PR TITLE
Docs finalization + sealing-console feasibility (#46, #48)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 
 # If `git secret init` is ever run against this repo itself
 .repo-enc/key
+
+# Editor cruft
+.obsidian/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,49 @@
+# Changelog
+
+## Unreleased — security hardening (#38–#48)
+
+A backlog reset focused on making the `GitSecret` CRD a defensible
+production-grade integration. No breaking changes; one additive CRD field
+(`spec.recipients`) and one additive nested field (`spec.target.adopt`).
+
+### Security & docs
+
+- **Threat model** (`docs/security/threat-model.md`), **design rationale**
+  (recovered ADR reasoning), **disaster-recovery runbooks**, **recipient &
+  key lifecycle**, **multi-cluster** and **cluster keyring** notes, and
+  `SECURITY.md`. The repo previously had no security documentation.
+- Recovery scenarios A–E are covered by tests in
+  `internal/sealer/recovery_test.go` — the loss-vs-compromise distinction is
+  explicit and asserted.
+
+### Controller
+
+- Refuses to adopt/clobber a `Secret` it does not own — reports a
+  `TargetConflict` condition instead. Opt in per target with
+  `spec.target.adopt: true`.
+- Bounds on `spec.encryptedData` (≤1024 entries via CRD `maxProperties`;
+  ≤1 MiB per encoded value) so a malformed object can't force unbounded
+  decryption.
+- Mirrors the recipient set into `status.recipients` / `status.recipientCount`
+  (new `Recipients` printer column); logs a warning if `spec.recipients` and
+  the wrapped blob disagree.
+
+### `git-secret-seal`
+
+- `spec.recipients` is written into every sealed manifest.
+- `recipients list|add|remove` subcommand — mutate the recipient set of an
+  existing manifest without retyping it; refuses to drop the last recipient or
+  the last `recovery`-role recipient without `--force`.
+- Recipient roles (`human` / `controller` / `recovery` / `deprecated`) recorded
+  in the `git-secret.opscalehub.io/recipient-roles` annotation.
+- `--keyring FILE` resolves recipients (and roles) from a committed keyring file.
+
+### `git-secret-controller`
+
+- `--print-public-key` — import the configured key and print its fingerprint +
+  armored public key, for handing to whoever seals to this controller.
+
+### CLI
+
+- `git secret init` prints a nudge when it falls back to the `file` backend,
+  which is incompatible with automated consumers.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,9 @@ gpg_recipients:            # gpg backend only — GPG fingerprints, not secret
 
 ### Key backends
 
-- **`file`** (default): a 32-byte key stored as hex in `key_source` (default `.repo-enc/key`), gitignored automatically by `init`. Giving a teammate access means copying this raw key to them out-of-band.
+**Use `gpg` for anything beyond a solo local repo** — it is the only backend that works with `git-secret-controller` or any automated consumer, and the only one where losing a single key doesn't threaten recoverability. `init` prints a nudge when it falls back to `file`.
+
+- **`file`** (default): a 32-byte key stored as hex in `key_source` (default `.repo-enc/key`), gitignored automatically by `init`. Giving a teammate access means copying this raw key to them out-of-band. Structurally incompatible with automated decryption — the key never enters git.
 - **`env`**: the key is read from the environment variable named by `key_source`. `init`/`rotate-keys` print an `export VAR=<hex>` line when they generate a new one — this backend can't persist anything to disk for you, so copy that value down before the process exits.
 - **`gpg`**: the same random 32-byte key, but wrapped (GPG-encrypted) to one or more recipients instead of stored raw. The wrapped blob (default `.repo-enc/key.gpg`) is **safe to commit** — unlike the `file` backend's key — since only a matching GPG private key can unwrap it. This solves the onboarding pain point above: a teammate who's already a configured recipient just needs `git secret init` (installs hooks; the committed config already has everything else) and their own existing keyring does the rest, no manual key transfer required.
 
@@ -318,7 +320,16 @@ git-secret-seal recipients list -f gitsecret.yaml       # who can decrypt, and t
 # ...or set the whole list explicitly:
 git-secret-seal --rewrap gitsecret.yaml \
   --recipient <controller-fingerprint> --recipient <your-own-fingerprint> --recipient <new-fingerprint>
+
+# ...or resolve recipients from a committed keyring file instead of typing them:
+git-secret-seal --namespace myapp --name my-secrets \
+  --keyring envs/prod/keyring.yaml --from-env-file app.env > gitsecret.yaml
 ```
+
+Get the controller's own fingerprint + public key with
+`git-secret-controller --gpg-private-key-file <key> --print-public-key`. See
+[docs/architecture/keyring.md](docs/architecture/keyring.md) for the keyring
+format and per-environment layout.
 
 The generated manifest records the fingerprints it was sealed to in
 `spec.recipients`, so adding or removing a recipient shows up as a one-line

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,27 @@
+# Documentation
+
+## Security
+
+- [threat-model.md](security/threat-model.md) — assets, trust boundaries, threats
+  (key *loss* vs *compromise*), invariants, non-goals.
+- [design-rationale.md](security/design-rationale.md) — why the architecture looks
+  the way it does; the four integration designs that led to the `GitSecret` CRD.
+- [disaster-recovery.md](security/disaster-recovery.md) — operator runbooks for
+  controller loss, cluster loss, key loss, key compromise.
+- [recipient-lifecycle.md](security/recipient-lifecycle.md) — recipient roles,
+  rotation workflows, and what removing a recipient does and does not undo.
+
+## Architecture
+
+- [overview.md](architecture/overview.md) — ASCII diagrams: seal → apply →
+  reconcile, the two-layer envelope, the recovery model.
+- [multi-cluster.md](architecture/multi-cluster.md) — one encrypted repo,
+  per-cluster controller identities, per-environment recipient sets.
+- [keyring.md](architecture/keyring.md) — `--print-public-key`,
+  `git-secret-seal --keyring`, discoverable recipient public keys.
+- [sealing-console.md](architecture/sealing-console.md) — feasibility analysis for
+  a web sealing UI (not scheduled).
+
+## Reporting a vulnerability
+
+See [SECURITY.md](../SECURITY.md).

--- a/docs/architecture/sealing-console.md
+++ b/docs/architecture/sealing-console.md
@@ -1,0 +1,66 @@
+# Sealing console — feasibility (not scheduled)
+
+Status: **design analysis only.** No console is built or planned. This records the
+thinking so a future decision starts from here instead of from scratch (#46).
+
+## What it would be
+
+A web UI for the `git-secret-seal` workflow: pick recipients, enter key/value
+pairs (or paste a `Secret` manifest), see the YAML, get a `GitSecret` manifest
+out. Nothing else.
+
+## What it is not, ever
+
+- **Not a decrypt endpoint.** Sealing is a one-way, public-key-only operation — it
+  needs recipient *public* keys and plaintext input, and produces ciphertext. It
+  never holds or needs a private key.
+- **Not part of `git-secret-controller`.** A separate binary / Deployment, always.
+  Bolting a sealing endpoint onto the always-on process that holds the decrypt
+  key is exactly the trust-domain mixing the CRD design exists to avoid.
+- **Not an authorization point.** The generated manifest still goes through
+  `kubectl apply` / ArgoCD / PR review. The apply path is the control boundary;
+  the console is an authoring convenience.
+
+## Deployment shapes
+
+| Shape | Exposure | Notes |
+|---|---|---|
+| **Local, CLI-launched** (`git-secret-seal ui`, binds `127.0.0.1`, auto-exits) | Lowest — plaintext never leaves the operator's machine | Same trust boundary as running the CLI today |
+| **In-cluster Deployment**, reached by `kubectl port-forward` (no Ingress) | Medium — see risks below | A shared, always-available authoring surface |
+| **In-cluster sidecar / one-shot Job** | Medium | On-demand variant of the above |
+
+## Residual risks for an in-cluster console, and mitigations
+
+1. **Plaintext in transit / in the pod.** *Mitigation:* do the GPG sealing
+   **client-side in the browser** (WASM OpenPGP). The server then serves only
+   static assets + the recipient public-key list (from the [keyring](keyring.md)),
+   and plaintext never leaves the browser tab. This is the design that makes
+   in-cluster ≈ as safe as local, and is the thing to **prototype first** before
+   committing.
+2. **Recipient substitution** (a compromised console seals to an attacker key
+   too). *Mitigation:* `spec.recipients` is visible in the manifest diff and the
+   manifest goes through review before it means anything.
+3. **Authz** (who may use it, for which namespace). *Mitigation:* not the
+   console's job — the apply path already gates this. Optionally put the
+   port-forward behind the cluster's normal auth proxy.
+
+## Hard dependency
+
+Recipient public-key discovery — **done** ([keyring.md](keyring.md):
+`git-secret-controller --print-public-key`, `git-secret-seal --keyring`). A
+console would build its recipient picker on the keyring file.
+
+## Recommendation
+
+**Not worth building now** — there is no demonstrated CLI pain; recent real
+production use went end-to-end on `git-secret-seal` without friction, and
+`--keyring` removes the "retype every fingerprint" annoyance that would have been
+the main driver.
+
+If sealing frequency grows enough that the CLI is a real bottleneck for several
+people, the path is:
+
+1. Prototype the **local, browser-side-crypto** shape (`git-secret-seal ui`).
+2. Only if a shared surface is genuinely needed, extend the *same* browser-side
+   -crypto build to an in-cluster Deployment behind `port-forward`.
+3. Never a server-side-seal endpoint; never on the controller.

--- a/docs/index.html
+++ b/docs/index.html
@@ -644,6 +644,7 @@ gpg_recipients:
         <p class="eyebrow">Beyond the CLI</p>
         <h2>GitSecret: a native CRD, ciphertext inline, no clone at all</h2>
         <p class="lede"><code>GitSecret</code> is a custom resource with its own controller — modeled on Bitnami <code>sealed-secrets</code>' shape, built on this project's existing multi-recipient GPG cryptography rather than one controller keypair. Ciphertext lives inline in the object, delivered by whatever already applies your manifests — ArgoCD, <code>kubectl apply</code> — with no repo clone, no SSH transport, and no network hop anywhere in the decrypt path.</p>
+        <p class="lede">The point isn't "GPG instead of a single keypair" — it's <strong>recovery independence</strong>: losing the cluster, the controller, or any one key doesn't make the secrets unrecoverable, as long as the encrypted repo and one authorized recipient key survive. See the <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret/blob/main/docs/security/threat-model.md" target="_blank" rel="noopener">threat model</a> and <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret/blob/main/docs/security/disaster-recovery.md" target="_blank" rel="noopener">disaster-recovery runbooks</a>.</p>
       </div>
 
       <div class="receipt" aria-label="git-secret-seal example session">
@@ -675,6 +676,14 @@ gpg_recipients:
           <div><h3>Bound to the exact object and key</h3><p>Every value's authenticated data is its <code>namespace/name/key</code> — an entry copied into a different <code>GitSecret</code>, or a renamed one, fails to decrypt instead of silently applying somewhere it wasn't sealed for.</p></div>
         </div>
         <div class="ledger-entry">
+          <span class="ledger-code">VISIBLE</span>
+          <div><h3>You can see who can decrypt</h3><p>The fingerprints sealed to are recorded in <code>spec.recipients</code> and mirrored to <code>status</code> — adding a recipient is a one-line diff in review, not an opaque blob change. Roles (<code>controller</code>, <code>recovery</code>, human) travel with the object; <code>git-secret-seal recipients</code> won't let you drop the last recovery key by accident.</p></div>
+        </div>
+        <div class="ledger-entry">
+          <span class="ledger-code">SAFE ADOPT</span>
+          <div><h3>Won't clobber a Secret it doesn't own</h3><p>If a <code>Secret</code> with the target name already exists and isn't managed by this <code>GitSecret</code>, the controller leaves it alone and reports a <code>TargetConflict</code> — taking it over needs an explicit <code>spec.target.adopt</code>.</p></div>
+        </div>
+        <div class="ledger-entry">
           <span class="ledger-code">OWNED</span>
           <div><h3>The CRD is the source of truth</h3><p>Built on <code>controller-runtime</code>. A <code>GitSecret</code> created fresh owns its target <code>Secret</code> outright: delete one, the other goes with it.</p></div>
         </div>
@@ -684,7 +693,7 @@ gpg_recipients:
         </div>
       </div>
 
-      <p class="lede" style="margin-top:var(--sp-3)">Early and not yet packaged as a Helm chart or container image — build <code>git-secret-controller</code> and <code>git-secret-seal</code> from source for now (<code>go build ./cmd/git-secret-controller</code>, <code>go build ./cmd/git-secret-seal</code>), and install the CRD from <code>config/crd/bases/</code>. Full usage and the <code>--rewrap</code> reference: <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret#gitsecret-crd-git-secret-controller" target="_blank" rel="noopener">README</a>.</p>
+      <p class="lede" style="margin-top:var(--sp-3)">A container image and Helm chart (<code>charts/git-secret-controller</code>) ship on every tagged release. Full usage — <code>recipients</code>, <code>--rewrap</code>, <code>--keyring</code>, disaster recovery — is in the <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret#gitsecret-crd-git-secret-controller" target="_blank" rel="noopener">README</a> and <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret/tree/main/docs" target="_blank" rel="noopener">docs/</a>.</p>
     </div>
   </section>
 


### PR DESCRIPTION
Final batch of the backlog reset — #46 (sealing-console feasibility) and #48
(documentation sweep). Docs only.

## #46 — sealing console feasibility

`docs/architecture/sealing-console.md`. Records the analysis so a future decision
doesn't start from scratch:
- One-way seal only — never a decrypt endpoint, never bolted onto the controller.
- Local (`git-secret-seal ui`, loopback) or in-cluster (standalone Deployment +
  `port-forward`); browser-side WASM crypto is the design that makes them
  ~equivalent in exposure.
- **Not scheduled** — no demonstrated CLI pain, and `--keyring` (#47) removed the
  "retype every fingerprint" friction that would have been the main driver.
- Prototype path recorded for if that changes.

## #48 — documentation consistency sweep

- `docs/README.md` — index of the eight security + architecture docs.
- `CHANGELOG.md` — the #38–#47 security-hardening arc, one entry.
- `README.md` — `--keyring` / `--print-public-key` in the GitSecret section; the
  "use `gpg` for anything beyond a solo repo" recommendation in Key backends.
- `docs/index.html`:
  - dropped the stale "not yet packaged as a Helm chart or container image" line
    (ships since 1bbdd6b);
  - CRD section now leads with recovery-independence and links the threat model +
    DR runbooks;
  - new `VISIBLE` (recipients on the object) and `SAFE ADOPT` (`TargetConflict`)
    ledger entries;
  - block-tag balance and in-page anchors verified, no dangling links.

## Deliberately not done

A hero-level visual reposition of `docs/index.html` (its "Plaintext on disk /
Ciphertext in history" identity is still accurate for the CLI half). Say the word
if you want the landing page's top-of-page framing rebuilt around the
control-plane thesis — that's a design task, not a text edit.

## After this

All backlog-reset issues (#38–#48) are addressed. Remaining follow-ups are
tracked in the threat-model open-items list (admission enforcement, keyring over
HTTP, a Helm publish-Job, Git provenance) — none blocking.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT
