### PR TITLE
ci: skip build/test matrix on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,10 +5,39 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      # true when something that can affect build/test/chart changed, or on
+      # any push to main (so main is always fully verified regardless of the
+      # merge's diff).
+      code: ${{ steps.filter.outputs.code == 'true' || github.event_name == 'push' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '**/*.go'
+              - 'go.mod'
+              - 'go.sum'
+              - 'charts/**'
+              - 'config/**'
+              - 'Dockerfile*'
+              - '.github/workflows/ci.yml'
+
   test:
     name: Build, vet, test
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -37,6 +66,8 @@ jobs:
 
   chart:
     name: Lint & render Helm chart
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -60,3 +91,25 @@ jobs:
           helm template test ./charts/git-secret-controller \
             --set gpgPrivateKey.existingSecret=dummy-gpg \
             --include-crds
+
+  ci-status:
+    name: CI status
+    # Single stable check to gate merges on: passes when the heavy jobs
+    # passed OR were legitimately skipped (docs-only change), fails if any
+    # actually failed or was cancelled. Make this the required status check
+    # in branch protection instead of the per-OS matrix legs.
+    if: always()
+    needs: [changes, test, chart]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        run: |
+          echo "test:  ${{ needs.test.result }}"
+          echo "chart: ${{ needs.chart.result }}"
+          for r in "${{ needs.test.result }}" "${{ needs.chart.result }}"; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "a required job did not succeed"
+              exit 1
+            fi
+          done
+          echo "ok"


### PR DESCRIPTION
## Problem

Every PR runs `go build/vet/test` on ubuntu + macOS + windows plus the Helm
render job, regardless of what changed. A docs-only PR (#53: six files, zero Go)
still paid ~2m18s of Windows time. `actions/setup-go` caches modules + build
cache, but `go test` results aren't persisted and several suites shell out to
`git`/`gpg` so Go won't cache them anyway.

## Change

- **`changes` gate job** (`dorny/paths-filter`) — `test` and `chart` now run only
  when `**/*.go`, `go.mod`/`go.sum`, `charts/**`, `config/**`, `Dockerfile*`, or
  the workflow itself changed. **Pushes to `main` always run the full matrix**
  (`|| github.event_name == 'push'`), so merged code is never under-tested.
- **`strategy.fail-fast: false`** — one OS failing no longer cancels the others
  (this masked the real failure twice during the recent security work).
- **`ci-status` summary job** — one always-run check that's green when the heavy
  jobs passed *or* were legitimately skipped, red if any actually failed.

## Action needed after merge

Point branch protection's **required status check** at **`CI status`** and drop
the per-OS `Build, vet, test (…)` entries — otherwise a skipped matrix on a docs
PR shows as "pending" and blocks merge. (Newer GitHub treats `skipped` as passing
for required checks, so this may already work, but the summary job is the robust
form.)

## Not included

Persisting `GOCACHE` across runs, and moving `windows-latest` to release-only —
both optional, deferred.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT