### PR TITLE
Keyring over HTTP + controller GET /pubkey (#56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,14 @@ production-grade integration. No breaking changes; one additive CRD field
 - Recipient roles (`human` / `controller` / `recovery` / `deprecated`) recorded
   in the `git-secret.opscalehub.io/recipient-roles` annotation.
 - `--keyring FILE` resolves recipients (and roles) from a committed keyring file.
+  `--keyring` also accepts an `http(s)://` URL.
 
 ### `git-secret-controller`
 
 - `--print-public-key` — import the configured key and print its fingerprint +
   armored public key, for handing to whoever seals to this controller.
+- `--serve-pubkey-address` — serve `GET /pubkey` (fingerprint + armored public
+  key) for discovery. Chart: `servePubKey.enabled`.
 - `--enable-webhook` — an optional validating admission webhook for `GitSecret`
   that rejects a `spec.recipients` / `encryptedKey` mismatch and enforces a
   per-namespace required-recipient set. Self-signed cert managed by the

--- a/charts/git-secret-controller/templates/deployment.yaml
+++ b/charts/git-secret-controller/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             - --webhook-service={{ include "git-secret-controller.fullname" . }}-webhook
             - --webhook-config-name={{ include "git-secret-controller.fullname" . }}
             {{- end }}
+            {{- if .Values.servePubKey.enabled }}
+            - --serve-pubkey-address=:{{ .Values.servePubKey.port }}
+            {{- end }}
           {{- if .Values.webhook.enabled }}
           env:
             - name: POD_NAMESPACE
@@ -59,6 +62,11 @@ spec:
             {{- if .Values.webhook.enabled }}
             - name: webhook
               containerPort: {{ .Values.webhook.port }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.servePubKey.enabled }}
+            - name: pubkey
+              containerPort: {{ .Values.servePubKey.port }}
               protocol: TCP
             {{- end }}
           livenessProbe:

--- a/charts/git-secret-controller/templates/pubkey-service.yaml
+++ b/charts/git-secret-controller/templates/pubkey-service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.servePubKey.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "git-secret-controller.fullname" . }}-pubkey
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "git-secret-controller.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: pubkey
+      protocol: TCP
+{{- end }}

--- a/charts/git-secret-controller/values.yaml
+++ b/charts/git-secret-controller/values.yaml
@@ -47,6 +47,15 @@ webhook:
   port: 9443
   failurePolicy: Fail
 
+# Serve GET /pubkey -- this controller's fingerprint on the first line,
+# then its armored public key -- so whoever seals GitSecrets to it can
+# fetch it (`curl http://<svc>/pubkey | gpg --import`) instead of it being
+# copied around by hand. Public data, no auth. Adds a ClusterIP Service on
+# port 80 -> the container port.
+servePubKey:
+  enabled: false
+  port: 8082
+
 resources:
   requests:
     cpu: 50m

--- a/cmd/git-secret-controller/main.go
+++ b/cmd/git-secret-controller/main.go
@@ -8,10 +8,13 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -19,6 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -51,6 +55,7 @@ func run(args []string, environ []string) int {
 	enableWebhook := fs.Bool("enable-webhook", false, "serve the GitSecret validating admission webhook (env ENABLE_WEBHOOK)")
 	webhookService := fs.String("webhook-service", "git-secret-controller-webhook", "name of the Service fronting the webhook, for the self-signed serving cert SAN (env WEBHOOK_SERVICE)")
 	webhookConfigName := fs.String("webhook-config-name", "git-secret-controller", "name of the ValidatingWebhookConfiguration to inject the self-signed CA into (env WEBHOOK_CONFIG_NAME)")
+	servePubKeyAddr := fs.String("serve-pubkey-address", "", "if set, serve GET /pubkey (this controller's fingerprint + armored public key) on this address, e.g. :8082 (env SERVE_PUBKEY_ADDRESS)")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
@@ -107,23 +112,26 @@ func run(args []string, environ []string) int {
 	}
 	gpgKey = nil
 
+	keys, err := gpgutil.ListSecretKeys()
+	if err != nil || len(keys) == 0 {
+		setupLog.Error(err, "list imported secret key")
+		return exitError
+	}
+	ownFingerprint := keys[0].Fingerprint
+	ownPubKey, err := gpgutil.ExportPublicKey(ownFingerprint)
+	if err != nil {
+		setupLog.Error(err, "export public key")
+		return exitError
+	}
+
 	if *printPublicKey {
-		keys, err := gpgutil.ListSecretKeys()
-		if err != nil || len(keys) == 0 {
-			setupLog.Error(err, "list imported secret key")
-			return exitError
-		}
-		pub, err := gpgutil.ExportPublicKey(keys[0].Fingerprint)
-		if err != nil {
-			setupLog.Error(err, "export public key")
-			return exitError
-		}
-		fmt.Println(keys[0].Fingerprint)
-		os.Stdout.Write(pub)
+		fmt.Println(ownFingerprint)
+		os.Stdout.Write(ownPubKey)
 		return 0
 	}
 
 	webhookOn := *enableWebhook || env["ENABLE_WEBHOOK"] == "true"
+	pubKeyAddr := firstNonEmpty(*servePubKeyAddr, env["SERVE_PUBKEY_ADDRESS"])
 
 	mgrOpts := ctrl.Options{
 		Scheme: scheme,
@@ -179,6 +187,14 @@ func run(args []string, environ []string) int {
 		setupLog.Info("validating webhook enabled", "path", gswebhook.WebhookPath)
 	}
 
+	if pubKeyAddr != "" {
+		if err := mgr.Add(servePubKey(pubKeyAddr, ownFingerprint, ownPubKey)); err != nil {
+			setupLog.Error(err, "unable to schedule pubkey server")
+			return exitError
+		}
+		setupLog.Info("serving GET /pubkey", "address", pubKeyAddr, "fingerprint", ownFingerprint)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		return exitError
@@ -200,6 +216,35 @@ const (
 	exitUsage = 2
 	exitError = 1
 )
+
+// servePubKey returns a manager.Runnable serving GET /pubkey -- the
+// controller's own fingerprint on the first line, then its armored public
+// key. Public data; no auth. Anything else 404s.
+func servePubKey(addr, fingerprint string, pub []byte) manager.Runnable {
+	body := append([]byte(fingerprint+"\n"), pub...)
+	return manager.RunnableFunc(func(ctx context.Context) error {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/pubkey", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Write(body)
+		})
+		srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+		go func() {
+			<-ctx.Done()
+			shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = srv.Shutdown(shutCtx)
+		}()
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	})
+}
 
 func envMap(environ []string) map[string]string {
 	m := make(map[string]string, len(environ))

--- a/cmd/git-secret-controller/main_test.go
+++ b/cmd/git-secret-controller/main_test.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/OpScaleHub/git-secret/internal/gpgutil"
 )
@@ -72,5 +76,50 @@ func TestPrintPublicKey(t *testing.T) {
 	first := strings.SplitN(strings.TrimSpace(out), "\n", 2)[0]
 	if len(first) != 40 {
 		t.Fatalf("first line is not a 40-hex fingerprint: %q", first)
+	}
+}
+
+func TestServePubKey(t *testing.T) {
+	const fpr = "ABCDEF0123456789ABCDEF0123456789ABCDEF01"
+	pub := []byte("-----BEGIN PGP PUBLIC KEY BLOCK-----\nx\n-----END PGP PUBLIC KEY BLOCK-----\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- servePubKey("127.0.0.1:38217", fpr, pub).Start(ctx) }()
+
+	var resp *http.Response
+	var err error
+	for i := 0; i < 50; i++ {
+		resp, err = http.Get("http://127.0.0.1:38217/pubkey")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("server never came up: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !strings.HasPrefix(string(got), fpr+"\n") || !strings.Contains(string(got), "BEGIN PGP PUBLIC KEY BLOCK") {
+		t.Fatalf("unexpected /pubkey body: %q", got)
+	}
+
+	r2, err := http.Post("http://127.0.0.1:38217/pubkey", "text/plain", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2.Body.Close()
+	if r2.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /pubkey = %d, want 405", r2.StatusCode)
+	}
+	if r3, _ := http.Get("http://127.0.0.1:38217/nope"); r3.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET /nope = %d, want 404", r3.StatusCode)
+	}
+
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("server exited with error: %v", err)
 	}
 }

--- a/cmd/git-secret-seal/keyring.go
+++ b/cmd/git-secret-seal/keyring.go
@@ -2,7 +2,11 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"strings"
+	"time"
 
 	sigsyaml "sigs.k8s.io/yaml"
 
@@ -28,17 +32,29 @@ type keyringFile struct {
 	} `json:"recipients"`
 }
 
-// loadKeyring reads path and returns its fingerprints (validated) and any
-// roles keyed by upper-case fingerprint.
-func loadKeyring(path string) (fingerprints []string, roles map[string]v1alpha1.RecipientRole, err error) {
-	raw, err := os.ReadFile(path)
+// loadKeyring reads a keyring from a local path or an http(s):// URL and
+// returns its fingerprints (validated) and any roles keyed by upper-case
+// fingerprint. A keyring is public data (fingerprints + roles, no key
+// material), so an https URL -- a raw file in the repo host, or a
+// controller endpoint -- is a fine source; plain http is allowed too but
+// the caller still needs each recipient's public key in their local
+// keyring to actually seal, so a tampered keyring fails closed at seal
+// time rather than leaking anything.
+func loadKeyring(src string) (fingerprints []string, roles map[string]v1alpha1.RecipientRole, err error) {
+	var raw []byte
+	if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
+		raw, err = fetchKeyring(src)
+	} else {
+		raw, err = os.ReadFile(src)
+	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("read keyring %s: %w", path, err)
+		return nil, nil, fmt.Errorf("read keyring %s: %w", src, err)
 	}
 	var kr keyringFile
 	if err := sigsyaml.Unmarshal(raw, &kr); err != nil {
-		return nil, nil, fmt.Errorf("parse keyring %s: %w", path, err)
+		return nil, nil, fmt.Errorf("parse keyring %s: %w", src, err)
 	}
+	path := src
 	if len(kr.Recipients) == 0 {
 		return nil, nil, fmt.Errorf("keyring %s lists no recipients", path)
 	}
@@ -63,6 +79,24 @@ func loadKeyring(path string) (fingerprints []string, roles map[string]v1alpha1.
 		}
 	}
 	return fingerprints, roles, nil
+}
+
+func fetchKeyring(url string) ([]byte, error) {
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	// Cap the body: a keyring is a handful of lines.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", url, err)
+	}
+	return body, nil
 }
 
 func upperFP(s string) string {

--- a/cmd/git-secret-seal/keyring_test.go
+++ b/cmd/git-secret-seal/keyring_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -75,5 +77,49 @@ func TestRun_KeyringRejectsBadFingerprint(t *testing.T) {
 	}
 	if !strings.Contains(errb.String(), "fingerprint") {
 		t.Fatalf("unexpected error: %s", errb.String())
+	}
+}
+
+func TestRun_KeyringFromHTTP(t *testing.T) {
+	home := shortTempDir(t)
+	fpr := genTestKey(t, home)
+	t.Setenv("GNUPGHOME", home)
+
+	keyring := "recipients:\n  - fingerprint: " + fpr + "\n    role: controller\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(keyring))
+	}))
+	defer srv.Close()
+
+	var out, errb bytes.Buffer
+	code := run([]string{
+		"--namespace", "ns", "--name", "obj",
+		"--keyring", srv.URL + "/keyring.yaml",
+		"--from-literal", "K=v",
+	}, &out, &errb)
+	if code != exitOK {
+		t.Fatalf("run() = %d: %s", code, errb.String())
+	}
+	var gs v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal(out.Bytes(), &gs); err != nil {
+		t.Fatal(err)
+	}
+	if len(gs.Spec.Recipients) != 1 || gs.Spec.Recipients[0] != fpr {
+		t.Fatalf("recipients from HTTP keyring = %v", gs.Spec.Recipients)
+	}
+	if v1alpha1.ParseRecipientRoles(gs.Annotations)[upperFP(fpr)] != v1alpha1.RoleController {
+		t.Fatalf("role from HTTP keyring not applied: %v", gs.Annotations)
+	}
+}
+
+func TestRun_KeyringHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	defer srv.Close()
+	var out, errb bytes.Buffer
+	code := run([]string{"--namespace", "ns", "--name", "o", "--keyring", srv.URL, "--from-literal", "K=v"}, &out, &errb)
+	if code == exitOK {
+		t.Fatal("expected failure on 404 keyring")
 	}
 }

--- a/docs/architecture/keyring.md
+++ b/docs/architecture/keyring.md
@@ -19,8 +19,13 @@ are not secret; nothing sensitive is exposed.
 
 Distribute it however suits you — commit it to the repo, drop it in a `ConfigMap`
 (`kubectl create configmap git-secret-controller-pubkey --from-literal=...`), or
-publish it internally. A Helm hook/Job to create that `ConfigMap` automatically
-is a planned follow-up (#47).
+have the controller serve it: `webhook`-style, set `servePubKey.enabled` in the
+chart (or `--serve-pubkey-address=:8082`) and it answers `GET /pubkey` with the
+fingerprint + armored key on a ClusterIP Service:
+
+```
+curl http://git-secret-controller-pubkey.<ns>.svc/pubkey | tail -n +2 | gpg --import
+```
 
 ## The keyring file
 
@@ -38,9 +43,10 @@ recipients:
     role: human
 ```
 
-`git-secret-seal --keyring keyring.yaml` adds every listed fingerprint to the
-recipient set (in addition to any `--recipient` flags) and records the roles in
-the manifest's `git-secret.opscalehub.io/recipient-roles` annotation:
+`git-secret-seal --keyring keyring.yaml` (or `--keyring https://…/keyring.yaml` —
+a raw file from the Git host, say) adds every listed fingerprint to the recipient
+set (in addition to any `--recipient` flags) and records the roles in the
+manifest's `git-secret.opscalehub.io/recipient-roles` annotation:
 
 ```
 git-secret-seal --namespace prod --name app-secrets \
@@ -59,10 +65,16 @@ distributing the actual public key material (WKD, a keyserver, committed `.asc`
 files) is out of scope — the keyring assumes the sealing operator already has the
 public keys in their GPG keyring, the same precondition `--recipient` already has.
 
+### Trust note on HTTP keyrings
+
+A keyring carries fingerprints and roles, not key material. A tampered keyring
+could add a fingerprint you don't intend — but `git-secret-seal` still needs that
+key's *public key* in your local GPG keyring to seal to it, so an injected
+fingerprint you don't have fails the seal outright rather than leaking anything.
+`https` is still recommended; `http` is allowed. Fetch failures fail closed.
+
 ## Not yet
 
-- `--keyring` accepts a local file path only. Fetching a keyring (or the
-  controller's `/pubkey`) over HTTP is a follow-up, with its own trust questions.
 - A `git-secret-seal keyring add/verify` helper to build and check the file.
-- Admission-webhook enforcement that a `GitSecret` under `envs/prod/**` matches
-  the prod keyring.
+- Admission enforcement is by Namespace annotation
+  ([admission-webhook.md](admission-webhook.md)), not yet full keyring matching.


### PR DESCRIPTION
**Stacked on #59** (`feat/admission-webhook`). Review/merge that first; this PR's
base will retarget to `main` once it lands.

## `git-secret-seal --keyring <url>`

`--keyring` now accepts an `http(s)://` URL as well as a file path — e.g. a raw
`keyring.yaml` served from the Git host. 15s timeout, 1 MiB body cap, fails
closed on non-200.

**Trust:** a keyring is public data (fingerprints + roles, no key material). A
tampered keyring that adds a fingerprint you don't hold the public key for just
fails the seal — it can't leak anything. Documented in `keyring.md`.

## `git-secret-controller --serve-pubkey-address`

Serves `GET /pubkey` — the controller's fingerprint on line 1, then its armored
public key. A manager `Runnable` with graceful shutdown; public, no auth,
everything else 404s. Chart: `servePubKey.enabled` → arg + container port + a
ClusterIP `Service` on `:80`.

```
curl http://git-secret-controller-pubkey.<ns>.svc/pubkey | tail -n +2 | gpg --import
```

## Tests

`httptest`-backed keyring fetch (success + 404) and a real `servePubKey` bind /
GET / 405 / 404 / clean-shutdown test. `helm lint`/`template` green.

Part of the deferred-follow-ups batch: #55 → **#56** → #57 → #58.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT