### PR TITLE
Helm hook Job to publish the controller pubkey as a ConfigMap (#57)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ production-grade integration. No breaking changes; one additive CRD field
   armored public key, for handing to whoever seals to this controller.
 - `--serve-pubkey-address` — serve `GET /pubkey` (fingerprint + armored public
   key) for discovery. Chart: `servePubKey.enabled`.
+- `--publish-public-key-configmap` — one-shot: upsert a ConfigMap with the
+  fingerprint + public key, then exit. Chart: `publishPublicKey.enabled` runs it
+  as a post-install/upgrade hook Job.
 - `--enable-webhook` — an optional validating admission webhook for `GitSecret`
   that rejects a `spec.recipients` / `encryptedKey` mismatch and enforces a
   per-namespace required-recipient set. Self-signed cert managed by the

--- a/charts/git-secret-controller/README.md
+++ b/charts/git-secret-controller/README.md
@@ -86,3 +86,18 @@ This adds RBAC for `namespaces` (get) and
 `validatingwebhookconfigurations` (get/update), a webhook `Service`, and
 a `POD_NAMESPACE` env via the downward API. Leave `webhook.failurePolicy`
 at `Fail`. See `docs/architecture/admission-webhook.md`.
+
+## Publishing the controller's public key
+
+Whoever seals `GitSecret`s to this controller needs its public key. Two
+optional ways to expose it:
+
+- `servePubKey.enabled` — the controller serves `GET /pubkey` on a
+  ClusterIP `Service` (fingerprint on line 1, then the armored key).
+- `publishPublicKey.enabled` — a post-install/upgrade hook `Job` writes
+  the fingerprint + public key into a `ConfigMap`
+  (`publishPublicKey.configMapName`, default `git-secret-controller-pubkey`),
+  which is nicer for GitOps / `kubectl get`.
+
+Both are off by default; use either or both. See
+`docs/architecture/keyring.md`.

--- a/charts/git-secret-controller/templates/pubkey-publish-job.yaml
+++ b/charts/git-secret-controller/templates/pubkey-publish-job.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.publishPublicKey.enabled }}
+{{- $name := printf "%s-publish-pubkey" (include "git-secret-controller.fullname" .) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "git-secret-controller.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $name }}
+      restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: publish
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          args:
+            - --gpg-private-key-file=/secrets/gpg/private.asc
+            - --publish-public-key-configmap={{ .Values.publishPublicKey.configMapName }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: gpg-private-key
+              mountPath: /secrets/gpg
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: gpg-private-key
+          secret:
+            secretName: {{ .Values.gpgPrivateKey.existingSecret }}
+            items:
+              - key: {{ .Values.gpgPrivateKey.existingSecretKey }}
+                path: private.asc
+                mode: 0400
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/git-secret-controller/values.yaml
+++ b/charts/git-secret-controller/values.yaml
@@ -56,6 +56,14 @@ servePubKey:
   enabled: false
   port: 8082
 
+# On install/upgrade, run a one-shot Job that writes the controller's
+# fingerprint + public key into a ConfigMap, so sealers can read it with
+# `kubectl get configmap` (GitOps-friendly, no running endpoint needed).
+# Complements servePubKey -- use either or both.
+publishPublicKey:
+  enabled: false
+  configMapName: git-secret-controller-pubkey
+
 resources:
   requests:
     cpu: 50m

--- a/cmd/git-secret-controller/main.go
+++ b/cmd/git-secret-controller/main.go
@@ -16,10 +16,14 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -56,6 +60,7 @@ func run(args []string, environ []string) int {
 	webhookService := fs.String("webhook-service", "git-secret-controller-webhook", "name of the Service fronting the webhook, for the self-signed serving cert SAN (env WEBHOOK_SERVICE)")
 	webhookConfigName := fs.String("webhook-config-name", "git-secret-controller", "name of the ValidatingWebhookConfiguration to inject the self-signed CA into (env WEBHOOK_CONFIG_NAME)")
 	servePubKeyAddr := fs.String("serve-pubkey-address", "", "if set, serve GET /pubkey (this controller's fingerprint + armored public key) on this address, e.g. :8082 (env SERVE_PUBKEY_ADDRESS)")
+	publishConfigMap := fs.String("publish-public-key-configmap", "", "if set, upsert a ConfigMap of this name (in POD_NAMESPACE) with the controller's fingerprint + public key and exit -- run as a one-shot Job (env PUBLISH_PUBLIC_KEY_CONFIGMAP)")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
@@ -127,6 +132,20 @@ func run(args []string, environ []string) int {
 	if *printPublicKey {
 		fmt.Println(ownFingerprint)
 		os.Stdout.Write(ownPubKey)
+		return 0
+	}
+
+	if cmName := firstNonEmpty(*publishConfigMap, env["PUBLISH_PUBLIC_KEY_CONFIGMAP"]); cmName != "" {
+		ns := firstNonEmpty(env["POD_NAMESPACE"], env["WEBHOOK_NAMESPACE"])
+		if ns == "" {
+			setupLog.Error(nil, "--publish-public-key-configmap needs POD_NAMESPACE set (downward API)")
+			return exitError
+		}
+		if err := publishPubKeyConfigMap(cmName, ns, ownFingerprint, ownPubKey); err != nil {
+			setupLog.Error(err, "publish public-key ConfigMap")
+			return exitError
+		}
+		setupLog.Info("published public-key ConfigMap", "name", cmName, "namespace", ns, "fingerprint", ownFingerprint)
 		return 0
 	}
 
@@ -216,6 +235,30 @@ const (
 	exitUsage = 2
 	exitError = 1
 )
+
+// publishPubKeyConfigMap upserts a ConfigMap holding the controller's own
+// fingerprint and armored public key, so sealers (or a keyring builder)
+// can read it with kubectl without the controller having to serve HTTP.
+// Intended to run as a one-shot Job.
+func publishPubKeyConfigMap(name, namespace, fingerprint string, pub []byte) error {
+	c, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("build client: %w", err)
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err = controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
+		cm.Data = map[string]string{
+			"fingerprint": fingerprint,
+			"publicKey":   string(pub),
+		}
+		return nil
+	})
+	return err
+}
 
 // servePubKey returns a manager.Runnable serving GET /pubkey -- the
 // controller's own fingerprint on the first line, then its armored public

--- a/docs/architecture/keyring.md
+++ b/docs/architecture/keyring.md
@@ -27,6 +27,10 @@ fingerprint + armored key on a ClusterIP Service:
 curl http://git-secret-controller-pubkey.<ns>.svc/pubkey | tail -n +2 | gpg --import
 ```
 
+Or have the chart write it to a ConfigMap on install/upgrade
+(`publishPublicKey.enabled`, a hook Job): `kubectl get configmap
+git-secret-controller-pubkey -o jsonpath='{.data.publicKey}' | gpg --import`.
+
 ## The keyring file
 
 A plain, committable file listing the recipients a repo (or an environment)


### PR DESCRIPTION
**Stacked on #60 → #59.** Merge order: #59, then #60, then this.

## `--publish-public-key-configmap NAME`

The controller imports its key and upserts a `ConfigMap` in `POD_NAMESPACE` with
`data.fingerprint` + `data.publicKey`, then exits. Uses the same controller-runtime
client machinery — no shell or `kubectl` in the image (it's `debian-slim`, no
kubectl).

## Chart

`publishPublicKey.enabled` runs it as a **post-install / post-upgrade hook Job**
with its own `ServiceAccount` + `Role` (`configmaps` get/create/update/patch),
`hook-delete-policy: before-hook-creation,hook-succeeded` for cleanup.
`publishPublicKey.configMapName` defaults to `git-secret-controller-pubkey`.

Complements #56's `servePubKey` (live HTTP endpoint) with a static,
`kubectl get`-able, GitOps-visible artifact. Use either or both.

`helm lint`/`template` green.

Part of the deferred-follow-ups batch: #55 → #56 → **#57** → #58.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT