### PR TITLE
GitSecret provenance: source-revision annotation + status (#58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,10 @@ production-grade integration. No breaking changes; one additive CRD field
 
 - `git secret init` prints a nudge when it falls back to the `file` backend,
   which is incompatible with automated consumers.
+
+### Provenance
+
+- `git-secret-seal` stamps `git-secret.opscalehub.io/source-revision` /
+  `source-repo` from the current Git HEAD (override `--source-revision`, disable
+  `--no-provenance`); the controller mirrors the revision to
+  `status.sourceRevision` (a `Revision` printer column).

--- a/README.md
+++ b/README.md
@@ -336,7 +336,10 @@ The generated manifest records the fingerprints it was sealed to in
 change in review rather than an opaque blob churn. The controller mirrors this
 to `status.recipients` / `status.recipientCount` (a `Recipients` column on
 `kubectl get gitsecret`) so you can see who can decrypt an object without
-inspecting the ciphertext.
+inspecting the ciphertext. It also stamps a
+`git-secret.opscalehub.io/source-revision` annotation from the current Git
+`HEAD`, mirrored to `status.sourceRevision`, so you can tell which commit a live
+`Secret` came from ([docs/architecture/provenance.md](docs/architecture/provenance.md)).
 
 Every `--recipient` must be a full 40/64-hex GPG fingerprint, not a short key
 ID or an email address — `git-secret-seal` rejects anything else, the same

--- a/api/v1alpha1/gitsecret_types.go
+++ b/api/v1alpha1/gitsecret_types.go
@@ -108,6 +108,13 @@ type GitSecretStatus struct {
 	// RecipientCount is len(spec.recipients), surfaced as a printer column.
 	// +optional
 	RecipientCount int `json:"recipientCount,omitempty"`
+
+	// SourceRevision echoes the git-secret.opscalehub.io/source-revision
+	// annotation (the commit git-secret-seal sealed the plaintext from), so
+	// `kubectl get gitsecret` answers "which commit produced this Secret?".
+	// Empty if the object carries no provenance annotation.
+	// +optional
+	SourceRevision string `json:"sourceRevision,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -117,6 +124,7 @@ type GitSecretStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Keys",type=integer,JSONPath=`.status.syncedKeys`
 // +kubebuilder:printcolumn:name="Recipients",type=integer,JSONPath=`.status.recipientCount`
+// +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.sourceRevision`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // GitSecret decrypts into a plain Kubernetes Secret via a controller that

--- a/api/v1alpha1/recipientroles.go
+++ b/api/v1alpha1/recipientroles.go
@@ -18,6 +18,16 @@ import (
 // plain "human" recipient.
 const RecipientRolesAnnotation = "git-secret.opscalehub.io/recipient-roles"
 
+// Provenance annotations, stamped by git-secret-seal when it runs inside a
+// Git working tree: the commit the plaintext was sealed from, and the
+// repository's origin URL. Informational -- the controller mirrors
+// SourceRevisionAnnotation into status.sourceRevision so an operator can
+// answer "which commit produced this Secret?" without leaving the cluster.
+const (
+	SourceRevisionAnnotation = "git-secret.opscalehub.io/source-revision"
+	SourceRepoAnnotation     = "git-secret.opscalehub.io/source-repo"
+)
+
 // RecipientRole classifies a recipient. See RecipientRolesAnnotation.
 type RecipientRole string
 

--- a/charts/git-secret-controller/crds/gitsecret.yaml
+++ b/charts/git-secret-controller/crds/gitsecret.yaml
@@ -29,6 +29,10 @@ spec:
     - jsonPath: .status.recipientCount
       name: Recipients
       type: integer
+    - jsonPath: .status.sourceRevision
+      name: Revision
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -223,6 +227,13 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: set
+              sourceRevision:
+                description: |-
+                  SourceRevision echoes the git-secret.opscalehub.io/source-revision
+                  annotation (the commit git-secret-seal sealed the plaintext from), so
+                  `kubectl get gitsecret` answers "which commit produced this Secret?".
+                  Empty if the object carries no provenance annotation.
+                type: string
               syncedKeys:
                 description: |-
                   SyncedKeys is the number of EncryptedData entries currently

--- a/cmd/git-secret-seal/main.go
+++ b/cmd/git-secret-seal/main.go
@@ -132,7 +132,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	fromSecretFile := fs.String("from-secret-file", "", "path to an existing Secret manifest to seal (- for stdin)")
 	fromEnvFile := fs.String("from-env-file", "", "path to a KEY=VALUE file to seal")
 	rewrapFile := fs.String("rewrap", "", "path to an existing GitSecret manifest to rewrap to a new --recipient list, without re-encrypting its values (- for stdin)")
-	keyringFile := fs.String("keyring", "", "path to a keyring file listing recipients (fingerprint + optional role); used in addition to any --recipient flags")
+	keyringFile := fs.String("keyring", "", "path to a keyring file (or http(s):// URL) listing recipients (fingerprint + optional role); used in addition to any --recipient flags")
+	sourceRevision := fs.String("source-revision", "", "override the provenance revision annotation (default: the current git HEAD, if run inside a repo)")
+	noProvenance := fs.Bool("no-provenance", false, "do not stamp the source-revision / source-repo provenance annotations")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	var literals stringSlice
 	var recipients stringSlice
@@ -261,6 +263,27 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// offline recovery key, etc.
 	if roleStr := v1alpha1.FormatRecipientRoles(keyringRoles); roleStr != "" {
 		gs.Annotations = map[string]string{v1alpha1.RecipientRolesAnnotation: roleStr}
+	}
+
+	// Stamp provenance: which commit the plaintext was sealed from. Lets
+	// `kubectl get gitsecret` / the controller status answer "which
+	// revision produced this Secret?" after the fact.
+	if !*noProvenance {
+		rev, repo := gitProvenance()
+		if *sourceRevision != "" {
+			rev = *sourceRevision
+		}
+		if rev != "" || repo != "" {
+			if gs.Annotations == nil {
+				gs.Annotations = map[string]string{}
+			}
+			if rev != "" {
+				gs.Annotations[v1alpha1.SourceRevisionAnnotation] = rev
+			}
+			if repo != "" {
+				gs.Annotations[v1alpha1.SourceRepoAnnotation] = repo
+			}
+		}
 	}
 
 	// sigs.k8s.io/yaml, not gopkg.in/yaml.v3: gs's fields carry only

--- a/cmd/git-secret-seal/main_test.go
+++ b/cmd/git-secret-seal/main_test.go
@@ -231,3 +231,38 @@ func TestRun_MissingRecipientIsUsageError(t *testing.T) {
 		t.Fatalf("run() = %d, want exitUsage; stderr: %s", code, stderr.String())
 	}
 }
+
+func TestRun_Provenance(t *testing.T) {
+	gnupgHome := shortTempDir(t)
+	fpr := genTestKey(t, gnupgHome)
+	t.Setenv("GNUPGHOME", gnupgHome)
+
+	base := []string{"--namespace", "ns", "--name", "obj", "--recipient", fpr, "--from-literal", "K=v"}
+
+	// Explicit --source-revision is stamped verbatim.
+	var out, errb bytes.Buffer
+	if code := run(append(base, "--source-revision", "abc123"), &out, &errb); code != exitOK {
+		t.Fatalf("run: %d %s", code, errb.String())
+	}
+	var gs v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal(out.Bytes(), &gs); err != nil {
+		t.Fatal(err)
+	}
+	if gs.Annotations[v1alpha1.SourceRevisionAnnotation] != "abc123" {
+		t.Fatalf("source-revision annotation = %q", gs.Annotations[v1alpha1.SourceRevisionAnnotation])
+	}
+
+	// --no-provenance omits both annotations.
+	out.Reset()
+	errb.Reset()
+	if code := run(append(base, "--no-provenance", "--source-revision", "abc123"), &out, &errb); code != exitOK {
+		t.Fatalf("run: %d %s", code, errb.String())
+	}
+	var gs2 v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal(out.Bytes(), &gs2); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := gs2.Annotations[v1alpha1.SourceRevisionAnnotation]; ok {
+		t.Fatalf("--no-provenance still stamped: %v", gs2.Annotations)
+	}
+}

--- a/cmd/git-secret-seal/provenance.go
+++ b/cmd/git-secret-seal/provenance.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// gitProvenance returns the current commit SHA and origin URL if the
+// working directory is inside a git repo, or empty strings otherwise.
+// Best-effort: git missing, not a repo, or no origin all just yield "".
+func gitProvenance() (revision, repo string) {
+	revision = gitOutput("rev-parse", "HEAD")
+	// A dirty tree means the sealed plaintext may not match the commit --
+	// flag it so the annotation isn't quietly misleading.
+	if revision != "" && gitOutput("status", "--porcelain") != "" {
+		revision += "-dirty"
+	}
+	repo = gitOutput("config", "--get", "remote.origin.url")
+	return revision, repo
+}
+
+func gitOutput(args ...string) string {
+	cmd := exec.Command("git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/config/crd/bases/git-secret.opscalehub.io_gitsecrets.yaml
+++ b/config/crd/bases/git-secret.opscalehub.io_gitsecrets.yaml
@@ -29,6 +29,10 @@ spec:
     - jsonPath: .status.recipientCount
       name: Recipients
       type: integer
+    - jsonPath: .status.sourceRevision
+      name: Revision
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -223,6 +227,13 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: set
+              sourceRevision:
+                description: |-
+                  SourceRevision echoes the git-secret.opscalehub.io/source-revision
+                  annotation (the commit git-secret-seal sealed the plaintext from), so
+                  `kubectl get gitsecret` answers "which commit produced this Secret?".
+                  Empty if the object carries no provenance annotation.
+                type: string
               syncedKeys:
                 description: |-
                   SyncedKeys is the number of EncryptedData entries currently

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@
   `git-secret-seal --keyring`, discoverable recipient public keys.
 - [admission-webhook.md](architecture/admission-webhook.md) — optional validating
   webhook enforcing `spec.recipients` and per-namespace required recipients.
+- [provenance.md](architecture/provenance.md) — recording which Git revision
+  produced a Secret.
 - [sealing-console.md](architecture/sealing-console.md) — feasibility analysis for
   a web sealing UI (not scheduled).
 

--- a/docs/architecture/provenance.md
+++ b/docs/architecture/provenance.md
@@ -1,0 +1,45 @@
+# Secret provenance
+
+Answering "which Git revision produced this `Secret`?" — threat-model T10.
+
+The controller reconciles whatever `GitSecret` object it is given; it has no notion
+of "newer", so a force-push or bad revert that delivers an old object version
+silently rolls the live `Secret` back. Provenance metadata makes that visible.
+
+## Two revisions, two sources
+
+| What | Set by | Where |
+|---|---|---|
+| The commit the **plaintext** was sealed from | `git-secret-seal` | `git-secret.opscalehub.io/source-revision` annotation → mirrored to `status.sourceRevision` |
+| The commit the **`GitSecret` object** was applied from | your GitOps tool | e.g. `argocd.argoproj.io/tracking-id`, or ArgoCD's app sync revision |
+
+`git-secret-seal` stamps its annotation automatically when run inside a Git
+working tree:
+
+```
+$ git-secret-seal --namespace prod --name app --recipient <fpr> --from-env-file app.env
+# gitsecret.yaml metadata.annotations:
+#   git-secret.opscalehub.io/source-revision: 4f2a1c9...        (HEAD, "-dirty" appended if the tree is dirty)
+#   git-secret.opscalehub.io/source-repo: git@github.com:org/app.git
+```
+
+- `--source-revision <sha>` overrides it (for CI that seals from a detached
+  checkout, or a build system that knows the real revision).
+- `--no-provenance` omits both annotations.
+
+`--rewrap` and `git-secret-seal recipients` preserve whatever annotations the
+object already has — provenance is set once, at seal time.
+
+## Reading it
+
+```
+kubectl get gitsecret app -n prod -o jsonpath='{.status.sourceRevision}'
+kubectl get gitsecret -n prod -o wide     # Revision column (priority 1)
+```
+
+## Not done (bigger design question)
+
+Rollback *protection* — a `spec` field naming a minimum/expected revision the
+controller refuses to go below — is deliberately out of scope here. It needs a
+trust model for who sets that field and how it is bumped, and is better as its
+own proposal. This change is only about making the current revision *observable*.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -80,7 +80,7 @@ Notation: **L** = availability/recovery, **C** = confidentiality, **I** = integr
 | T7 | Plaintext leak via logs / Events / `status` / metrics | C | **Invariant (I3), regression-tested.** `TestUnseal_ErrorDoesNotLeakPlaintext` asserts a tampered-envelope failure never echoes the plaintext into the returned error (which the controller copies into `.status`). |
 | T8 | Malicious cluster administrator | C | **Out of scope.** Anyone who can `kubectl get secret -o yaml` wins without touching `git-secret`. |
 | T9 | Compromised controller pod | C | Blast radius = `GitSecret`s wrapped to the controller key. Mitigation: don't wrap every object to every controller — per-cluster / per-env recipient sets ([multi-cluster.md](../architecture/multi-cluster.md)); `runAsNonRoot`, read-only rootfs, minimal RBAC. |
-| T10 | Rollback / history-rewrite of a `GitSecret` in Git | I | An old object version re-applied re-installs old secret values silently. Provenance (which Git revision produced this Secret) is not surfaced — future work. |
+| T10 | Rollback / history-rewrite of a `GitSecret` in Git | I | **Observable, not yet prevented.** `git-secret-seal` stamps `source-revision` and the controller mirrors it to `status.sourceRevision` (a `Revision` printer column), so a rollback is visible ([provenance.md](../architecture/provenance.md)). Refusing to go below an expected revision is a separate design question. |
 | T11 | Recipient substitution — object sealed to an attacker key alongside the real ones | C | **Handled** (review + optional enforcement). `spec.recipients` lists the fingerprints on the object (one-line diff in review); the optional [validating webhook](../architecture/admission-webhook.md) rejects a `GitSecret` whose `spec.recipients` count disagrees with the blob, and enforces a per-namespace required-recipient set. Without the webhook it is still a controller warning. |
 | T12 | Pre-existing target `Secret` silently adopted & cleared | I | **Handled.** A colliding `Secret` this `GitSecret` does not own is left untouched and a `TargetConflict` Ready=False condition is set, unless the operator opts in with `spec.target.adopt`. Tests `TestReconcile_DoesNotClobberUnownedSecret` / `_AdoptsUnownedSecretWhenOptedIn`. |
 | T13 | Plaintext committed to Git (CLI path) | C | **Handled.** `verify` + the `pre-push` hook fail closed; `SECRETIZE_SKIP_HOOKS` is opt-in per-invocation, never tied to ambient `CI`. |
@@ -135,9 +135,8 @@ regression regardless of the feature it enables.
 ## 6. Open items feeding this model
 
 Keyring-over-HTTP (#56) · a Helm Job to publish the controller pubkey `ConfigMap`
-(#57) · provenance / which-Git-revision-produced-this-Secret (#58, T10) ·
-webhook matching against a full keyring object rather than the Namespace
-annotation.
+(#57) · rollback *protection* (a min-revision `spec` field, T10) · webhook
+matching against a full keyring object rather than the Namespace annotation.
 
 Closed: #38 (this doc) · #39 (DR runbooks + tests) · #40 (`spec.recipients` +
 status mirror + `VerifyRecipients`) · #41 (recipient roles + `git-secret-seal
@@ -145,4 +144,6 @@ recipients` + [lifecycle doc](recipient-lifecycle.md)) · #42 (controller adopti
 guard, input bounds, status-leak regression test) · #43
 ([multi-cluster.md](../architecture/multi-cluster.md)) · #47
 ([keyring.md](../architecture/keyring.md): `--print-public-key`, `--keyring`) ·
-#55 ([admission-webhook.md](../architecture/admission-webhook.md)).
+#55 ([admission-webhook.md](../architecture/admission-webhook.md)) · #56/#57
+(keyring over HTTP, `--serve-pubkey`, pubkey ConfigMap Job) · #58
+([provenance.md](../architecture/provenance.md)).

--- a/internal/controller/gitsecret_controller.go
+++ b/internal/controller/gitsecret_controller.go
@@ -64,6 +64,7 @@ func (r *GitSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// object even while it is failing to reconcile.
 	gs.Status.Recipients = gs.Spec.Recipients
 	gs.Status.RecipientCount = len(gs.Spec.Recipients)
+	gs.Status.SourceRevision = gs.Annotations[gitsecretv1alpha1.SourceRevisionAnnotation]
 	if err := sealer.VerifyRecipients(gs.Spec); err != nil {
 		// Non-fatal: the authoritative recipient set is the blob itself,
 		// which the decrypt path below uses directly. A mismatch just

--- a/internal/controller/gitsecret_controller_test.go
+++ b/internal/controller/gitsecret_controller_test.go
@@ -98,8 +98,12 @@ func TestReconcile_CreatesTargetSecret(t *testing.T) {
 	}
 
 	gs := &gitsecretv1alpha1.GitSecret{
-		ObjectMeta: metav1.ObjectMeta{Name: "downtime-secrets", Namespace: "downtime"},
-		Spec:       spec,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "downtime-secrets",
+			Namespace:   "downtime",
+			Annotations: map[string]string{gitsecretv1alpha1.SourceRevisionAnnotation: "deadbeefcafe"},
+		},
+		Spec: spec,
 	}
 
 	scheme := newScheme(t)
@@ -139,6 +143,9 @@ func TestReconcile_CreatesTargetSecret(t *testing.T) {
 	}
 	if updated.Status.RecipientCount != 1 || len(updated.Status.Recipients) != 1 || updated.Status.Recipients[0] != fpr {
 		t.Errorf("status recipients = %v (count %d), want [%s] (1)", updated.Status.Recipients, updated.Status.RecipientCount, fpr)
+	}
+	if updated.Status.SourceRevision != "deadbeefcafe" {
+		t.Errorf("status.sourceRevision = %q, want deadbeefcafe", updated.Status.SourceRevision)
 	}
 	found := false
 	for _, c := range updated.Status.Conditions {


### PR DESCRIPTION
**Stacked on #61 → #60 → #59.** Merge order: #59, #60, #61, then this.

Makes "which Git revision produced this `Secret`?" answerable (threat-model T10).
**Observable, not prevented** — refusing to reconcile below an expected revision
is a separate design question, deliberately out of scope.

## `git-secret-seal`

Stamps two annotations when run inside a Git working tree:
- `git-secret.opscalehub.io/source-revision` — `git HEAD` (`-dirty` suffix if the
  tree is dirty)
- `git-secret.opscalehub.io/source-repo` — `remote.origin.url`

Best-effort: no `git` / not a repo → no annotation. `--source-revision <sha>`
overrides (for CI sealing from a detached checkout); `--no-provenance` disables.
`--rewrap` / `recipients` preserve existing annotations — provenance is set once.

## Controller

`GitSecretStatus.SourceRevision` mirrors the annotation every reconcile. New
`Revision` printer column (priority 1, shows with `-o wide`).

```
kubectl get gitsecret app -n prod -o jsonpath='{.status.sourceRevision}'
```

## Docs

`docs/architecture/provenance.md` (incl. the ArgoCD-side revision for the *object*
vs the seal-side revision for the *plaintext*); README, CHANGELOG, threat-model
T10, docs index. CRD + deepcopy regenerated.

Final of the deferred-follow-ups batch: #55 → #56 → #57 → **#58**.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT