### PR TITLE
Land #56, #57, #58 on main (stacked PRs merged into intermediate branches)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,9 @@ production-grade integration. No breaking changes; one additive CRD field
   armored public key, for handing to whoever seals to this controller.
 - `--serve-pubkey-address` — serve `GET /pubkey` (fingerprint + armored public
   key) for discovery. Chart: `servePubKey.enabled`.
+- `--publish-public-key-configmap` — one-shot: upsert a ConfigMap with the
+  fingerprint + public key, then exit. Chart: `publishPublicKey.enabled` runs it
+  as a post-install/upgrade hook Job.
 - `--enable-webhook` — an optional validating admission webhook for `GitSecret`
   that rejects a `spec.recipients` / `encryptedKey` mismatch and enforces a
   per-namespace required-recipient set. Self-signed cert managed by the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,3 +57,10 @@ production-grade integration. No breaking changes; one additive CRD field
 
 - `git secret init` prints a nudge when it falls back to the `file` backend,
   which is incompatible with automated consumers.
+
+### Provenance
+
+- `git-secret-seal` stamps `git-secret.opscalehub.io/source-revision` /
+  `source-repo` from the current Git HEAD (override `--source-revision`, disable
+  `--no-provenance`); the controller mirrors the revision to
+  `status.sourceRevision` (a `Revision` printer column).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,11 +37,14 @@ production-grade integration. No breaking changes; one additive CRD field
 - Recipient roles (`human` / `controller` / `recovery` / `deprecated`) recorded
   in the `git-secret.opscalehub.io/recipient-roles` annotation.
 - `--keyring FILE` resolves recipients (and roles) from a committed keyring file.
+  `--keyring` also accepts an `http(s)://` URL.
 
 ### `git-secret-controller`
 
 - `--print-public-key` — import the configured key and print its fingerprint +
   armored public key, for handing to whoever seals to this controller.
+- `--serve-pubkey-address` — serve `GET /pubkey` (fingerprint + armored public
+  key) for discovery. Chart: `servePubKey.enabled`.
 - `--enable-webhook` — an optional validating admission webhook for `GitSecret`
   that rejects a `spec.recipients` / `encryptedKey` mismatch and enforces a
   per-namespace required-recipient set. Self-signed cert managed by the

--- a/README.md
+++ b/README.md
@@ -336,7 +336,10 @@ The generated manifest records the fingerprints it was sealed to in
 change in review rather than an opaque blob churn. The controller mirrors this
 to `status.recipients` / `status.recipientCount` (a `Recipients` column on
 `kubectl get gitsecret`) so you can see who can decrypt an object without
-inspecting the ciphertext.
+inspecting the ciphertext. It also stamps a
+`git-secret.opscalehub.io/source-revision` annotation from the current Git
+`HEAD`, mirrored to `status.sourceRevision`, so you can tell which commit a live
+`Secret` came from ([docs/architecture/provenance.md](docs/architecture/provenance.md)).
 
 Every `--recipient` must be a full 40/64-hex GPG fingerprint, not a short key
 ID or an email address — `git-secret-seal` rejects anything else, the same

--- a/api/v1alpha1/gitsecret_types.go
+++ b/api/v1alpha1/gitsecret_types.go
@@ -108,6 +108,13 @@ type GitSecretStatus struct {
 	// RecipientCount is len(spec.recipients), surfaced as a printer column.
 	// +optional
 	RecipientCount int `json:"recipientCount,omitempty"`
+
+	// SourceRevision echoes the git-secret.opscalehub.io/source-revision
+	// annotation (the commit git-secret-seal sealed the plaintext from), so
+	// `kubectl get gitsecret` answers "which commit produced this Secret?".
+	// Empty if the object carries no provenance annotation.
+	// +optional
+	SourceRevision string `json:"sourceRevision,omitempty"`
 }
 
 // +kubebuilder:object:root=true
@@ -117,6 +124,7 @@ type GitSecretStatus struct {
 // +kubebuilder:printcolumn:name="Ready",type=string,JSONPath=`.status.conditions[?(@.type=="Ready")].status`
 // +kubebuilder:printcolumn:name="Keys",type=integer,JSONPath=`.status.syncedKeys`
 // +kubebuilder:printcolumn:name="Recipients",type=integer,JSONPath=`.status.recipientCount`
+// +kubebuilder:printcolumn:name="Revision",type=string,JSONPath=`.status.sourceRevision`,priority=1
 // +kubebuilder:printcolumn:name="Age",type=date,JSONPath=`.metadata.creationTimestamp`
 
 // GitSecret decrypts into a plain Kubernetes Secret via a controller that

--- a/api/v1alpha1/recipientroles.go
+++ b/api/v1alpha1/recipientroles.go
@@ -18,6 +18,16 @@ import (
 // plain "human" recipient.
 const RecipientRolesAnnotation = "git-secret.opscalehub.io/recipient-roles"
 
+// Provenance annotations, stamped by git-secret-seal when it runs inside a
+// Git working tree: the commit the plaintext was sealed from, and the
+// repository's origin URL. Informational -- the controller mirrors
+// SourceRevisionAnnotation into status.sourceRevision so an operator can
+// answer "which commit produced this Secret?" without leaving the cluster.
+const (
+	SourceRevisionAnnotation = "git-secret.opscalehub.io/source-revision"
+	SourceRepoAnnotation     = "git-secret.opscalehub.io/source-repo"
+)
+
 // RecipientRole classifies a recipient. See RecipientRolesAnnotation.
 type RecipientRole string
 

--- a/charts/git-secret-controller/README.md
+++ b/charts/git-secret-controller/README.md
@@ -86,3 +86,18 @@ This adds RBAC for `namespaces` (get) and
 `validatingwebhookconfigurations` (get/update), a webhook `Service`, and
 a `POD_NAMESPACE` env via the downward API. Leave `webhook.failurePolicy`
 at `Fail`. See `docs/architecture/admission-webhook.md`.
+
+## Publishing the controller's public key
+
+Whoever seals `GitSecret`s to this controller needs its public key. Two
+optional ways to expose it:
+
+- `servePubKey.enabled` — the controller serves `GET /pubkey` on a
+  ClusterIP `Service` (fingerprint on line 1, then the armored key).
+- `publishPublicKey.enabled` — a post-install/upgrade hook `Job` writes
+  the fingerprint + public key into a `ConfigMap`
+  (`publishPublicKey.configMapName`, default `git-secret-controller-pubkey`),
+  which is nicer for GitOps / `kubectl get`.
+
+Both are off by default; use either or both. See
+`docs/architecture/keyring.md`.

--- a/charts/git-secret-controller/crds/gitsecret.yaml
+++ b/charts/git-secret-controller/crds/gitsecret.yaml
@@ -29,6 +29,10 @@ spec:
     - jsonPath: .status.recipientCount
       name: Recipients
       type: integer
+    - jsonPath: .status.sourceRevision
+      name: Revision
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -223,6 +227,13 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: set
+              sourceRevision:
+                description: |-
+                  SourceRevision echoes the git-secret.opscalehub.io/source-revision
+                  annotation (the commit git-secret-seal sealed the plaintext from), so
+                  `kubectl get gitsecret` answers "which commit produced this Secret?".
+                  Empty if the object carries no provenance annotation.
+                type: string
               syncedKeys:
                 description: |-
                   SyncedKeys is the number of EncryptedData entries currently

--- a/charts/git-secret-controller/templates/deployment.yaml
+++ b/charts/git-secret-controller/templates/deployment.yaml
@@ -42,6 +42,9 @@ spec:
             - --webhook-service={{ include "git-secret-controller.fullname" . }}-webhook
             - --webhook-config-name={{ include "git-secret-controller.fullname" . }}
             {{- end }}
+            {{- if .Values.servePubKey.enabled }}
+            - --serve-pubkey-address=:{{ .Values.servePubKey.port }}
+            {{- end }}
           {{- if .Values.webhook.enabled }}
           env:
             - name: POD_NAMESPACE
@@ -59,6 +62,11 @@ spec:
             {{- if .Values.webhook.enabled }}
             - name: webhook
               containerPort: {{ .Values.webhook.port }}
+              protocol: TCP
+            {{- end }}
+            {{- if .Values.servePubKey.enabled }}
+            - name: pubkey
+              containerPort: {{ .Values.servePubKey.port }}
               protocol: TCP
             {{- end }}
           livenessProbe:

--- a/charts/git-secret-controller/templates/pubkey-publish-job.yaml
+++ b/charts/git-secret-controller/templates/pubkey-publish-job.yaml
@@ -1,0 +1,101 @@
+{{- if .Values.publishPublicKey.enabled }}
+{{- $name := printf "%s-publish-pubkey" (include "git-secret-controller.fullname" .) }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+rules:
+  - apiGroups: [""]
+    resources: ["configmaps"]
+    verbs: ["get", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "-5"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $name }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $name }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      labels:
+        {{- include "git-secret-controller.selectorLabels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $name }}
+      restartPolicy: Never
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: publish
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          args:
+            - --gpg-private-key-file=/secrets/gpg/private.asc
+            - --publish-public-key-configmap={{ .Values.publishPublicKey.configMapName }}
+          env:
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: gpg-private-key
+              mountPath: /secrets/gpg
+              readOnly: true
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: gpg-private-key
+          secret:
+            secretName: {{ .Values.gpgPrivateKey.existingSecret }}
+            items:
+              - key: {{ .Values.gpgPrivateKey.existingSecretKey }}
+                path: private.asc
+                mode: 0400
+        - name: tmp
+          emptyDir: {}
+{{- end }}

--- a/charts/git-secret-controller/templates/pubkey-service.yaml
+++ b/charts/git-secret-controller/templates/pubkey-service.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.servePubKey.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "git-secret-controller.fullname" . }}-pubkey
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+spec:
+  selector:
+    {{- include "git-secret-controller.selectorLabels" . | nindent 4 }}
+  ports:
+    - name: http
+      port: 80
+      targetPort: pubkey
+      protocol: TCP
+{{- end }}

--- a/charts/git-secret-controller/values.yaml
+++ b/charts/git-secret-controller/values.yaml
@@ -47,6 +47,15 @@ webhook:
   port: 9443
   failurePolicy: Fail
 
+# Serve GET /pubkey -- this controller's fingerprint on the first line,
+# then its armored public key -- so whoever seals GitSecrets to it can
+# fetch it (`curl http://<svc>/pubkey | gpg --import`) instead of it being
+# copied around by hand. Public data, no auth. Adds a ClusterIP Service on
+# port 80 -> the container port.
+servePubKey:
+  enabled: false
+  port: 8082
+
 resources:
   requests:
     cpu: 50m

--- a/charts/git-secret-controller/values.yaml
+++ b/charts/git-secret-controller/values.yaml
@@ -56,6 +56,14 @@ servePubKey:
   enabled: false
   port: 8082
 
+# On install/upgrade, run a one-shot Job that writes the controller's
+# fingerprint + public key into a ConfigMap, so sealers can read it with
+# `kubectl get configmap` (GitOps-friendly, no running endpoint needed).
+# Complements servePubKey -- use either or both.
+publishPublicKey:
+  enabled: false
+  configMapName: git-secret-controller-pubkey
+
 resources:
   requests:
     cpu: 50m

--- a/cmd/git-secret-controller/main.go
+++ b/cmd/git-secret-controller/main.go
@@ -16,10 +16,14 @@ import (
 	"strings"
 	"time"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -56,6 +60,7 @@ func run(args []string, environ []string) int {
 	webhookService := fs.String("webhook-service", "git-secret-controller-webhook", "name of the Service fronting the webhook, for the self-signed serving cert SAN (env WEBHOOK_SERVICE)")
 	webhookConfigName := fs.String("webhook-config-name", "git-secret-controller", "name of the ValidatingWebhookConfiguration to inject the self-signed CA into (env WEBHOOK_CONFIG_NAME)")
 	servePubKeyAddr := fs.String("serve-pubkey-address", "", "if set, serve GET /pubkey (this controller's fingerprint + armored public key) on this address, e.g. :8082 (env SERVE_PUBKEY_ADDRESS)")
+	publishConfigMap := fs.String("publish-public-key-configmap", "", "if set, upsert a ConfigMap of this name (in POD_NAMESPACE) with the controller's fingerprint + public key and exit -- run as a one-shot Job (env PUBLISH_PUBLIC_KEY_CONFIGMAP)")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
@@ -127,6 +132,20 @@ func run(args []string, environ []string) int {
 	if *printPublicKey {
 		fmt.Println(ownFingerprint)
 		os.Stdout.Write(ownPubKey)
+		return 0
+	}
+
+	if cmName := firstNonEmpty(*publishConfigMap, env["PUBLISH_PUBLIC_KEY_CONFIGMAP"]); cmName != "" {
+		ns := firstNonEmpty(env["POD_NAMESPACE"], env["WEBHOOK_NAMESPACE"])
+		if ns == "" {
+			setupLog.Error(nil, "--publish-public-key-configmap needs POD_NAMESPACE set (downward API)")
+			return exitError
+		}
+		if err := publishPubKeyConfigMap(cmName, ns, ownFingerprint, ownPubKey); err != nil {
+			setupLog.Error(err, "publish public-key ConfigMap")
+			return exitError
+		}
+		setupLog.Info("published public-key ConfigMap", "name", cmName, "namespace", ns, "fingerprint", ownFingerprint)
 		return 0
 	}
 
@@ -216,6 +235,30 @@ const (
 	exitUsage = 2
 	exitError = 1
 )
+
+// publishPubKeyConfigMap upserts a ConfigMap holding the controller's own
+// fingerprint and armored public key, so sealers (or a keyring builder)
+// can read it with kubectl without the controller having to serve HTTP.
+// Intended to run as a one-shot Job.
+func publishPubKeyConfigMap(name, namespace, fingerprint string, pub []byte) error {
+	c, err := client.New(ctrl.GetConfigOrDie(), client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("build client: %w", err)
+	}
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	_, err = controllerutil.CreateOrUpdate(ctx, c, cm, func() error {
+		cm.Data = map[string]string{
+			"fingerprint": fingerprint,
+			"publicKey":   string(pub),
+		}
+		return nil
+	})
+	return err
+}
 
 // servePubKey returns a manager.Runnable serving GET /pubkey -- the
 // controller's own fingerprint on the first line, then its armored public

--- a/cmd/git-secret-controller/main.go
+++ b/cmd/git-secret-controller/main.go
@@ -8,10 +8,13 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -19,6 +22,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	crwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
@@ -51,6 +55,7 @@ func run(args []string, environ []string) int {
 	enableWebhook := fs.Bool("enable-webhook", false, "serve the GitSecret validating admission webhook (env ENABLE_WEBHOOK)")
 	webhookService := fs.String("webhook-service", "git-secret-controller-webhook", "name of the Service fronting the webhook, for the self-signed serving cert SAN (env WEBHOOK_SERVICE)")
 	webhookConfigName := fs.String("webhook-config-name", "git-secret-controller", "name of the ValidatingWebhookConfiguration to inject the self-signed CA into (env WEBHOOK_CONFIG_NAME)")
+	servePubKeyAddr := fs.String("serve-pubkey-address", "", "if set, serve GET /pubkey (this controller's fingerprint + armored public key) on this address, e.g. :8082 (env SERVE_PUBKEY_ADDRESS)")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	if err := fs.Parse(args); err != nil {
 		return exitUsage
@@ -107,23 +112,26 @@ func run(args []string, environ []string) int {
 	}
 	gpgKey = nil
 
+	keys, err := gpgutil.ListSecretKeys()
+	if err != nil || len(keys) == 0 {
+		setupLog.Error(err, "list imported secret key")
+		return exitError
+	}
+	ownFingerprint := keys[0].Fingerprint
+	ownPubKey, err := gpgutil.ExportPublicKey(ownFingerprint)
+	if err != nil {
+		setupLog.Error(err, "export public key")
+		return exitError
+	}
+
 	if *printPublicKey {
-		keys, err := gpgutil.ListSecretKeys()
-		if err != nil || len(keys) == 0 {
-			setupLog.Error(err, "list imported secret key")
-			return exitError
-		}
-		pub, err := gpgutil.ExportPublicKey(keys[0].Fingerprint)
-		if err != nil {
-			setupLog.Error(err, "export public key")
-			return exitError
-		}
-		fmt.Println(keys[0].Fingerprint)
-		os.Stdout.Write(pub)
+		fmt.Println(ownFingerprint)
+		os.Stdout.Write(ownPubKey)
 		return 0
 	}
 
 	webhookOn := *enableWebhook || env["ENABLE_WEBHOOK"] == "true"
+	pubKeyAddr := firstNonEmpty(*servePubKeyAddr, env["SERVE_PUBKEY_ADDRESS"])
 
 	mgrOpts := ctrl.Options{
 		Scheme: scheme,
@@ -179,6 +187,14 @@ func run(args []string, environ []string) int {
 		setupLog.Info("validating webhook enabled", "path", gswebhook.WebhookPath)
 	}
 
+	if pubKeyAddr != "" {
+		if err := mgr.Add(servePubKey(pubKeyAddr, ownFingerprint, ownPubKey)); err != nil {
+			setupLog.Error(err, "unable to schedule pubkey server")
+			return exitError
+		}
+		setupLog.Info("serving GET /pubkey", "address", pubKeyAddr, "fingerprint", ownFingerprint)
+	}
+
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {
 		setupLog.Error(err, "unable to set up health check")
 		return exitError
@@ -200,6 +216,35 @@ const (
 	exitUsage = 2
 	exitError = 1
 )
+
+// servePubKey returns a manager.Runnable serving GET /pubkey -- the
+// controller's own fingerprint on the first line, then its armored public
+// key. Public data; no auth. Anything else 404s.
+func servePubKey(addr, fingerprint string, pub []byte) manager.Runnable {
+	body := append([]byte(fingerprint+"\n"), pub...)
+	return manager.RunnableFunc(func(ctx context.Context) error {
+		mux := http.NewServeMux()
+		mux.HandleFunc("/pubkey", func(w http.ResponseWriter, r *http.Request) {
+			if r.Method != http.MethodGet {
+				http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+				return
+			}
+			w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+			w.Write(body)
+		})
+		srv := &http.Server{Addr: addr, Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+		go func() {
+			<-ctx.Done()
+			shutCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			_ = srv.Shutdown(shutCtx)
+		}()
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			return err
+		}
+		return nil
+	})
+}
 
 func envMap(environ []string) map[string]string {
 	m := make(map[string]string, len(environ))

--- a/cmd/git-secret-controller/main_test.go
+++ b/cmd/git-secret-controller/main_test.go
@@ -2,11 +2,15 @@ package main
 
 import (
 	"bytes"
+	"context"
+	"io"
+	"net/http"
 	"os"
 	"os/exec"
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/OpScaleHub/git-secret/internal/gpgutil"
 )
@@ -72,5 +76,50 @@ func TestPrintPublicKey(t *testing.T) {
 	first := strings.SplitN(strings.TrimSpace(out), "\n", 2)[0]
 	if len(first) != 40 {
 		t.Fatalf("first line is not a 40-hex fingerprint: %q", first)
+	}
+}
+
+func TestServePubKey(t *testing.T) {
+	const fpr = "ABCDEF0123456789ABCDEF0123456789ABCDEF01"
+	pub := []byte("-----BEGIN PGP PUBLIC KEY BLOCK-----\nx\n-----END PGP PUBLIC KEY BLOCK-----\n")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	errCh := make(chan error, 1)
+	go func() { errCh <- servePubKey("127.0.0.1:38217", fpr, pub).Start(ctx) }()
+
+	var resp *http.Response
+	var err error
+	for i := 0; i < 50; i++ {
+		resp, err = http.Get("http://127.0.0.1:38217/pubkey")
+		if err == nil {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("server never came up: %v", err)
+	}
+	got, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if !strings.HasPrefix(string(got), fpr+"\n") || !strings.Contains(string(got), "BEGIN PGP PUBLIC KEY BLOCK") {
+		t.Fatalf("unexpected /pubkey body: %q", got)
+	}
+
+	r2, err := http.Post("http://127.0.0.1:38217/pubkey", "text/plain", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	r2.Body.Close()
+	if r2.StatusCode != http.StatusMethodNotAllowed {
+		t.Fatalf("POST /pubkey = %d, want 405", r2.StatusCode)
+	}
+	if r3, _ := http.Get("http://127.0.0.1:38217/nope"); r3.StatusCode != http.StatusNotFound {
+		t.Fatalf("GET /nope = %d, want 404", r3.StatusCode)
+	}
+
+	cancel()
+	if err := <-errCh; err != nil {
+		t.Fatalf("server exited with error: %v", err)
 	}
 }

--- a/cmd/git-secret-seal/keyring.go
+++ b/cmd/git-secret-seal/keyring.go
@@ -2,7 +2,11 @@ package main
 
 import (
 	"fmt"
+	"io"
+	"net/http"
 	"os"
+	"strings"
+	"time"
 
 	sigsyaml "sigs.k8s.io/yaml"
 
@@ -28,17 +32,29 @@ type keyringFile struct {
 	} `json:"recipients"`
 }
 
-// loadKeyring reads path and returns its fingerprints (validated) and any
-// roles keyed by upper-case fingerprint.
-func loadKeyring(path string) (fingerprints []string, roles map[string]v1alpha1.RecipientRole, err error) {
-	raw, err := os.ReadFile(path)
+// loadKeyring reads a keyring from a local path or an http(s):// URL and
+// returns its fingerprints (validated) and any roles keyed by upper-case
+// fingerprint. A keyring is public data (fingerprints + roles, no key
+// material), so an https URL -- a raw file in the repo host, or a
+// controller endpoint -- is a fine source; plain http is allowed too but
+// the caller still needs each recipient's public key in their local
+// keyring to actually seal, so a tampered keyring fails closed at seal
+// time rather than leaking anything.
+func loadKeyring(src string) (fingerprints []string, roles map[string]v1alpha1.RecipientRole, err error) {
+	var raw []byte
+	if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
+		raw, err = fetchKeyring(src)
+	} else {
+		raw, err = os.ReadFile(src)
+	}
 	if err != nil {
-		return nil, nil, fmt.Errorf("read keyring %s: %w", path, err)
+		return nil, nil, fmt.Errorf("read keyring %s: %w", src, err)
 	}
 	var kr keyringFile
 	if err := sigsyaml.Unmarshal(raw, &kr); err != nil {
-		return nil, nil, fmt.Errorf("parse keyring %s: %w", path, err)
+		return nil, nil, fmt.Errorf("parse keyring %s: %w", src, err)
 	}
+	path := src
 	if len(kr.Recipients) == 0 {
 		return nil, nil, fmt.Errorf("keyring %s lists no recipients", path)
 	}
@@ -63,6 +79,24 @@ func loadKeyring(path string) (fingerprints []string, roles map[string]v1alpha1.
 		}
 	}
 	return fingerprints, roles, nil
+}
+
+func fetchKeyring(url string) ([]byte, error) {
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(url)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: %s", url, resp.Status)
+	}
+	// Cap the body: a keyring is a handful of lines.
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", url, err)
+	}
+	return body, nil
 }
 
 func upperFP(s string) string {

--- a/cmd/git-secret-seal/keyring_test.go
+++ b/cmd/git-secret-seal/keyring_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
@@ -75,5 +77,49 @@ func TestRun_KeyringRejectsBadFingerprint(t *testing.T) {
 	}
 	if !strings.Contains(errb.String(), "fingerprint") {
 		t.Fatalf("unexpected error: %s", errb.String())
+	}
+}
+
+func TestRun_KeyringFromHTTP(t *testing.T) {
+	home := shortTempDir(t)
+	fpr := genTestKey(t, home)
+	t.Setenv("GNUPGHOME", home)
+
+	keyring := "recipients:\n  - fingerprint: " + fpr + "\n    role: controller\n"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(keyring))
+	}))
+	defer srv.Close()
+
+	var out, errb bytes.Buffer
+	code := run([]string{
+		"--namespace", "ns", "--name", "obj",
+		"--keyring", srv.URL + "/keyring.yaml",
+		"--from-literal", "K=v",
+	}, &out, &errb)
+	if code != exitOK {
+		t.Fatalf("run() = %d: %s", code, errb.String())
+	}
+	var gs v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal(out.Bytes(), &gs); err != nil {
+		t.Fatal(err)
+	}
+	if len(gs.Spec.Recipients) != 1 || gs.Spec.Recipients[0] != fpr {
+		t.Fatalf("recipients from HTTP keyring = %v", gs.Spec.Recipients)
+	}
+	if v1alpha1.ParseRecipientRoles(gs.Annotations)[upperFP(fpr)] != v1alpha1.RoleController {
+		t.Fatalf("role from HTTP keyring not applied: %v", gs.Annotations)
+	}
+}
+
+func TestRun_KeyringHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusNotFound)
+	}))
+	defer srv.Close()
+	var out, errb bytes.Buffer
+	code := run([]string{"--namespace", "ns", "--name", "o", "--keyring", srv.URL, "--from-literal", "K=v"}, &out, &errb)
+	if code == exitOK {
+		t.Fatal("expected failure on 404 keyring")
 	}
 }

--- a/cmd/git-secret-seal/main.go
+++ b/cmd/git-secret-seal/main.go
@@ -132,7 +132,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	fromSecretFile := fs.String("from-secret-file", "", "path to an existing Secret manifest to seal (- for stdin)")
 	fromEnvFile := fs.String("from-env-file", "", "path to a KEY=VALUE file to seal")
 	rewrapFile := fs.String("rewrap", "", "path to an existing GitSecret manifest to rewrap to a new --recipient list, without re-encrypting its values (- for stdin)")
-	keyringFile := fs.String("keyring", "", "path to a keyring file listing recipients (fingerprint + optional role); used in addition to any --recipient flags")
+	keyringFile := fs.String("keyring", "", "path to a keyring file (or http(s):// URL) listing recipients (fingerprint + optional role); used in addition to any --recipient flags")
+	sourceRevision := fs.String("source-revision", "", "override the provenance revision annotation (default: the current git HEAD, if run inside a repo)")
+	noProvenance := fs.Bool("no-provenance", false, "do not stamp the source-revision / source-repo provenance annotations")
 	showVersion := fs.Bool("version", false, "print version and exit")
 	var literals stringSlice
 	var recipients stringSlice
@@ -261,6 +263,27 @@ func run(args []string, stdout, stderr io.Writer) int {
 	// offline recovery key, etc.
 	if roleStr := v1alpha1.FormatRecipientRoles(keyringRoles); roleStr != "" {
 		gs.Annotations = map[string]string{v1alpha1.RecipientRolesAnnotation: roleStr}
+	}
+
+	// Stamp provenance: which commit the plaintext was sealed from. Lets
+	// `kubectl get gitsecret` / the controller status answer "which
+	// revision produced this Secret?" after the fact.
+	if !*noProvenance {
+		rev, repo := gitProvenance()
+		if *sourceRevision != "" {
+			rev = *sourceRevision
+		}
+		if rev != "" || repo != "" {
+			if gs.Annotations == nil {
+				gs.Annotations = map[string]string{}
+			}
+			if rev != "" {
+				gs.Annotations[v1alpha1.SourceRevisionAnnotation] = rev
+			}
+			if repo != "" {
+				gs.Annotations[v1alpha1.SourceRepoAnnotation] = repo
+			}
+		}
 	}
 
 	// sigs.k8s.io/yaml, not gopkg.in/yaml.v3: gs's fields carry only

--- a/cmd/git-secret-seal/main_test.go
+++ b/cmd/git-secret-seal/main_test.go
@@ -231,3 +231,38 @@ func TestRun_MissingRecipientIsUsageError(t *testing.T) {
 		t.Fatalf("run() = %d, want exitUsage; stderr: %s", code, stderr.String())
 	}
 }
+
+func TestRun_Provenance(t *testing.T) {
+	gnupgHome := shortTempDir(t)
+	fpr := genTestKey(t, gnupgHome)
+	t.Setenv("GNUPGHOME", gnupgHome)
+
+	base := []string{"--namespace", "ns", "--name", "obj", "--recipient", fpr, "--from-literal", "K=v"}
+
+	// Explicit --source-revision is stamped verbatim.
+	var out, errb bytes.Buffer
+	if code := run(append(base, "--source-revision", "abc123"), &out, &errb); code != exitOK {
+		t.Fatalf("run: %d %s", code, errb.String())
+	}
+	var gs v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal(out.Bytes(), &gs); err != nil {
+		t.Fatal(err)
+	}
+	if gs.Annotations[v1alpha1.SourceRevisionAnnotation] != "abc123" {
+		t.Fatalf("source-revision annotation = %q", gs.Annotations[v1alpha1.SourceRevisionAnnotation])
+	}
+
+	// --no-provenance omits both annotations.
+	out.Reset()
+	errb.Reset()
+	if code := run(append(base, "--no-provenance", "--source-revision", "abc123"), &out, &errb); code != exitOK {
+		t.Fatalf("run: %d %s", code, errb.String())
+	}
+	var gs2 v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal(out.Bytes(), &gs2); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := gs2.Annotations[v1alpha1.SourceRevisionAnnotation]; ok {
+		t.Fatalf("--no-provenance still stamped: %v", gs2.Annotations)
+	}
+}

--- a/cmd/git-secret-seal/provenance.go
+++ b/cmd/git-secret-seal/provenance.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// gitProvenance returns the current commit SHA and origin URL if the
+// working directory is inside a git repo, or empty strings otherwise.
+// Best-effort: git missing, not a repo, or no origin all just yield "".
+func gitProvenance() (revision, repo string) {
+	revision = gitOutput("rev-parse", "HEAD")
+	// A dirty tree means the sealed plaintext may not match the commit --
+	// flag it so the annotation isn't quietly misleading.
+	if revision != "" && gitOutput("status", "--porcelain") != "" {
+		revision += "-dirty"
+	}
+	repo = gitOutput("config", "--get", "remote.origin.url")
+	return revision, repo
+}
+
+func gitOutput(args ...string) string {
+	cmd := exec.Command("git", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}

--- a/config/crd/bases/git-secret.opscalehub.io_gitsecrets.yaml
+++ b/config/crd/bases/git-secret.opscalehub.io_gitsecrets.yaml
@@ -29,6 +29,10 @@ spec:
     - jsonPath: .status.recipientCount
       name: Recipients
       type: integer
+    - jsonPath: .status.sourceRevision
+      name: Revision
+      priority: 1
+      type: string
     - jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
@@ -223,6 +227,13 @@ spec:
                   type: string
                 type: array
                 x-kubernetes-list-type: set
+              sourceRevision:
+                description: |-
+                  SourceRevision echoes the git-secret.opscalehub.io/source-revision
+                  annotation (the commit git-secret-seal sealed the plaintext from), so
+                  `kubectl get gitsecret` answers "which commit produced this Secret?".
+                  Empty if the object carries no provenance annotation.
+                type: string
               syncedKeys:
                 description: |-
                   SyncedKeys is the number of EncryptedData entries currently

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,8 @@
   `git-secret-seal --keyring`, discoverable recipient public keys.
 - [admission-webhook.md](architecture/admission-webhook.md) — optional validating
   webhook enforcing `spec.recipients` and per-namespace required recipients.
+- [provenance.md](architecture/provenance.md) — recording which Git revision
+  produced a Secret.
 - [sealing-console.md](architecture/sealing-console.md) — feasibility analysis for
   a web sealing UI (not scheduled).
 

--- a/docs/architecture/keyring.md
+++ b/docs/architecture/keyring.md
@@ -27,6 +27,10 @@ fingerprint + armored key on a ClusterIP Service:
 curl http://git-secret-controller-pubkey.<ns>.svc/pubkey | tail -n +2 | gpg --import
 ```
 
+Or have the chart write it to a ConfigMap on install/upgrade
+(`publishPublicKey.enabled`, a hook Job): `kubectl get configmap
+git-secret-controller-pubkey -o jsonpath='{.data.publicKey}' | gpg --import`.
+
 ## The keyring file
 
 A plain, committable file listing the recipients a repo (or an environment)

--- a/docs/architecture/keyring.md
+++ b/docs/architecture/keyring.md
@@ -19,8 +19,13 @@ are not secret; nothing sensitive is exposed.
 
 Distribute it however suits you — commit it to the repo, drop it in a `ConfigMap`
 (`kubectl create configmap git-secret-controller-pubkey --from-literal=...`), or
-publish it internally. A Helm hook/Job to create that `ConfigMap` automatically
-is a planned follow-up (#47).
+have the controller serve it: `webhook`-style, set `servePubKey.enabled` in the
+chart (or `--serve-pubkey-address=:8082`) and it answers `GET /pubkey` with the
+fingerprint + armored key on a ClusterIP Service:
+
+```
+curl http://git-secret-controller-pubkey.<ns>.svc/pubkey | tail -n +2 | gpg --import
+```
 
 ## The keyring file
 
@@ -38,9 +43,10 @@ recipients:
     role: human
 ```
 
-`git-secret-seal --keyring keyring.yaml` adds every listed fingerprint to the
-recipient set (in addition to any `--recipient` flags) and records the roles in
-the manifest's `git-secret.opscalehub.io/recipient-roles` annotation:
+`git-secret-seal --keyring keyring.yaml` (or `--keyring https://…/keyring.yaml` —
+a raw file from the Git host, say) adds every listed fingerprint to the recipient
+set (in addition to any `--recipient` flags) and records the roles in the
+manifest's `git-secret.opscalehub.io/recipient-roles` annotation:
 
 ```
 git-secret-seal --namespace prod --name app-secrets \
@@ -59,10 +65,16 @@ distributing the actual public key material (WKD, a keyserver, committed `.asc`
 files) is out of scope — the keyring assumes the sealing operator already has the
 public keys in their GPG keyring, the same precondition `--recipient` already has.
 
+### Trust note on HTTP keyrings
+
+A keyring carries fingerprints and roles, not key material. A tampered keyring
+could add a fingerprint you don't intend — but `git-secret-seal` still needs that
+key's *public key* in your local GPG keyring to seal to it, so an injected
+fingerprint you don't have fails the seal outright rather than leaking anything.
+`https` is still recommended; `http` is allowed. Fetch failures fail closed.
+
 ## Not yet
 
-- `--keyring` accepts a local file path only. Fetching a keyring (or the
-  controller's `/pubkey`) over HTTP is a follow-up, with its own trust questions.
 - A `git-secret-seal keyring add/verify` helper to build and check the file.
-- Admission-webhook enforcement that a `GitSecret` under `envs/prod/**` matches
-  the prod keyring.
+- Admission enforcement is by Namespace annotation
+  ([admission-webhook.md](admission-webhook.md)), not yet full keyring matching.

--- a/docs/architecture/provenance.md
+++ b/docs/architecture/provenance.md
@@ -1,0 +1,45 @@
+# Secret provenance
+
+Answering "which Git revision produced this `Secret`?" — threat-model T10.
+
+The controller reconciles whatever `GitSecret` object it is given; it has no notion
+of "newer", so a force-push or bad revert that delivers an old object version
+silently rolls the live `Secret` back. Provenance metadata makes that visible.
+
+## Two revisions, two sources
+
+| What | Set by | Where |
+|---|---|---|
+| The commit the **plaintext** was sealed from | `git-secret-seal` | `git-secret.opscalehub.io/source-revision` annotation → mirrored to `status.sourceRevision` |
+| The commit the **`GitSecret` object** was applied from | your GitOps tool | e.g. `argocd.argoproj.io/tracking-id`, or ArgoCD's app sync revision |
+
+`git-secret-seal` stamps its annotation automatically when run inside a Git
+working tree:
+
+```
+$ git-secret-seal --namespace prod --name app --recipient <fpr> --from-env-file app.env
+# gitsecret.yaml metadata.annotations:
+#   git-secret.opscalehub.io/source-revision: 4f2a1c9...        (HEAD, "-dirty" appended if the tree is dirty)
+#   git-secret.opscalehub.io/source-repo: git@github.com:org/app.git
+```
+
+- `--source-revision <sha>` overrides it (for CI that seals from a detached
+  checkout, or a build system that knows the real revision).
+- `--no-provenance` omits both annotations.
+
+`--rewrap` and `git-secret-seal recipients` preserve whatever annotations the
+object already has — provenance is set once, at seal time.
+
+## Reading it
+
+```
+kubectl get gitsecret app -n prod -o jsonpath='{.status.sourceRevision}'
+kubectl get gitsecret -n prod -o wide     # Revision column (priority 1)
+```
+
+## Not done (bigger design question)
+
+Rollback *protection* — a `spec` field naming a minimum/expected revision the
+controller refuses to go below — is deliberately out of scope here. It needs a
+trust model for who sets that field and how it is bumped, and is better as its
+own proposal. This change is only about making the current revision *observable*.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -80,7 +80,7 @@ Notation: **L** = availability/recovery, **C** = confidentiality, **I** = integr
 | T7 | Plaintext leak via logs / Events / `status` / metrics | C | **Invariant (I3), regression-tested.** `TestUnseal_ErrorDoesNotLeakPlaintext` asserts a tampered-envelope failure never echoes the plaintext into the returned error (which the controller copies into `.status`). |
 | T8 | Malicious cluster administrator | C | **Out of scope.** Anyone who can `kubectl get secret -o yaml` wins without touching `git-secret`. |
 | T9 | Compromised controller pod | C | Blast radius = `GitSecret`s wrapped to the controller key. Mitigation: don't wrap every object to every controller — per-cluster / per-env recipient sets ([multi-cluster.md](../architecture/multi-cluster.md)); `runAsNonRoot`, read-only rootfs, minimal RBAC. |
-| T10 | Rollback / history-rewrite of a `GitSecret` in Git | I | An old object version re-applied re-installs old secret values silently. Provenance (which Git revision produced this Secret) is not surfaced — future work. |
+| T10 | Rollback / history-rewrite of a `GitSecret` in Git | I | **Observable, not yet prevented.** `git-secret-seal` stamps `source-revision` and the controller mirrors it to `status.sourceRevision` (a `Revision` printer column), so a rollback is visible ([provenance.md](../architecture/provenance.md)). Refusing to go below an expected revision is a separate design question. |
 | T11 | Recipient substitution — object sealed to an attacker key alongside the real ones | C | **Handled** (review + optional enforcement). `spec.recipients` lists the fingerprints on the object (one-line diff in review); the optional [validating webhook](../architecture/admission-webhook.md) rejects a `GitSecret` whose `spec.recipients` count disagrees with the blob, and enforces a per-namespace required-recipient set. Without the webhook it is still a controller warning. |
 | T12 | Pre-existing target `Secret` silently adopted & cleared | I | **Handled.** A colliding `Secret` this `GitSecret` does not own is left untouched and a `TargetConflict` Ready=False condition is set, unless the operator opts in with `spec.target.adopt`. Tests `TestReconcile_DoesNotClobberUnownedSecret` / `_AdoptsUnownedSecretWhenOptedIn`. |
 | T13 | Plaintext committed to Git (CLI path) | C | **Handled.** `verify` + the `pre-push` hook fail closed; `SECRETIZE_SKIP_HOOKS` is opt-in per-invocation, never tied to ambient `CI`. |
@@ -135,9 +135,8 @@ regression regardless of the feature it enables.
 ## 6. Open items feeding this model
 
 Keyring-over-HTTP (#56) · a Helm Job to publish the controller pubkey `ConfigMap`
-(#57) · provenance / which-Git-revision-produced-this-Secret (#58, T10) ·
-webhook matching against a full keyring object rather than the Namespace
-annotation.
+(#57) · rollback *protection* (a min-revision `spec` field, T10) · webhook
+matching against a full keyring object rather than the Namespace annotation.
 
 Closed: #38 (this doc) · #39 (DR runbooks + tests) · #40 (`spec.recipients` +
 status mirror + `VerifyRecipients`) · #41 (recipient roles + `git-secret-seal
@@ -145,4 +144,6 @@ recipients` + [lifecycle doc](recipient-lifecycle.md)) · #42 (controller adopti
 guard, input bounds, status-leak regression test) · #43
 ([multi-cluster.md](../architecture/multi-cluster.md)) · #47
 ([keyring.md](../architecture/keyring.md): `--print-public-key`, `--keyring`) ·
-#55 ([admission-webhook.md](../architecture/admission-webhook.md)).
+#55 ([admission-webhook.md](../architecture/admission-webhook.md)) · #56/#57
+(keyring over HTTP, `--serve-pubkey`, pubkey ConfigMap Job) · #58
+([provenance.md](../architecture/provenance.md)).

--- a/internal/controller/gitsecret_controller.go
+++ b/internal/controller/gitsecret_controller.go
@@ -64,6 +64,7 @@ func (r *GitSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// object even while it is failing to reconcile.
 	gs.Status.Recipients = gs.Spec.Recipients
 	gs.Status.RecipientCount = len(gs.Spec.Recipients)
+	gs.Status.SourceRevision = gs.Annotations[gitsecretv1alpha1.SourceRevisionAnnotation]
 	if err := sealer.VerifyRecipients(gs.Spec); err != nil {
 		// Non-fatal: the authoritative recipient set is the blob itself,
 		// which the decrypt path below uses directly. A mismatch just

--- a/internal/controller/gitsecret_controller_test.go
+++ b/internal/controller/gitsecret_controller_test.go
@@ -98,8 +98,12 @@ func TestReconcile_CreatesTargetSecret(t *testing.T) {
 	}
 
 	gs := &gitsecretv1alpha1.GitSecret{
-		ObjectMeta: metav1.ObjectMeta{Name: "downtime-secrets", Namespace: "downtime"},
-		Spec:       spec,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "downtime-secrets",
+			Namespace:   "downtime",
+			Annotations: map[string]string{gitsecretv1alpha1.SourceRevisionAnnotation: "deadbeefcafe"},
+		},
+		Spec: spec,
 	}
 
 	scheme := newScheme(t)
@@ -139,6 +143,9 @@ func TestReconcile_CreatesTargetSecret(t *testing.T) {
 	}
 	if updated.Status.RecipientCount != 1 || len(updated.Status.Recipients) != 1 || updated.Status.Recipients[0] != fpr {
 		t.Errorf("status recipients = %v (count %d), want [%s] (1)", updated.Status.Recipients, updated.Status.RecipientCount, fpr)
+	}
+	if updated.Status.SourceRevision != "deadbeefcafe" {
+		t.Errorf("status.sourceRevision = %q, want deadbeefcafe", updated.Status.SourceRevision)
 	}
 	found := false
 	for _, c := range updated.Status.Conditions {


### PR DESCRIPTION
## What happened

PRs #60 (#56), #61 (#57), #62 (#58) were a stack. They each merged **into their
intermediate base branch** (`feat/admission-webhook`, `feat/keyring-http`,
`feat/publish-pubkey-configmap`) rather than `main` — GitHub didn't auto-retarget
the base when #59 merged. So only #55 (via #59) and the CI change (#54) actually
reached `main`; #56/#57/#58's commits are stranded on the now-dead stack branches.

## This PR

Cherry-picks the three commits onto current `main` (clean, no conflicts). `#54`'s
CI workflow change is untouched.

- **#56** — `git-secret-seal --keyring <https url>`; `git-secret-controller
  --serve-pubkey-address` → `GET /pubkey`; chart `servePubKey`.
- **#57** — `--publish-public-key-configmap` + chart `publishPublicKey` hook Job.
- **#58** — `git-secret-seal` stamps `source-revision`/`source-repo`; controller
  mirrors to `status.sourceRevision` + `Revision` printer column.

`go build/vet/test` + `helm lint` green locally. CRD + deepcopy already
regenerated in the picked commits.

After merge: the stale branches (`feat/admission-webhook`, `feat/keyring-http`,
`feat/publish-pubkey-configmap`, `feat/provenance`, `ci/skip-matrix-on-docs-only`)
can be deleted.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT