### PR TITLE
release: finalize CHANGELOG for v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 # Changelog
 
-## Unreleased — security hardening (#38–#48)
+## v0.8.0 — 2026-08-27 — security hardening (#38–#58)
 
 A backlog reset focused on making the `GitSecret` CRD a defensible
-production-grade integration. No breaking changes; one additive CRD field
-(`spec.recipients`) and one additive nested field (`spec.target.adopt`).
+production-grade integration. No breaking changes; additive CRD fields only
+(`spec.recipients`, `spec.target.adopt`, `status.recipients` /
+`status.recipientCount` / `status.sourceRevision`).
 
 ### Security & docs
 


### PR DESCRIPTION
Prep for cutting **v0.8.0** (previous release: v0.7.1).

- `CHANGELOG.md`: `Unreleased` → `v0.8.0 — 2026-08-27`, issue range widened to
  #38–#58.

No code change. `Chart.yaml` versions left at their committed value — the release
workflow sets the published chart version/appVersion from the tag, by design.

## After merge

Tag `v0.8.0` on the merge commit and push it → the release workflow builds:
- client binaries (`git-secret`, `kubectl-secret`, `git-secret-seal`) for
  linux/darwin/windows × amd64/arm64,
- `git-secret-controller` + `git-secret-server` container images to GHCR,
- both Helm charts as OCI to `ghcr.io/opscalehub/charts`,
- a GitHub Release with all attached.

Semver: minor bump — new features, fully backward-compatible (additive CRD fields
and opt-in flags/chart values only).

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT