### PR TITLE
feat: git-secret-seal ui — public-key-only sealing web form (#46)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,7 +38,12 @@ production-grade integration. No breaking changes; additive CRD fields only
 - Recipient roles (`human` / `controller` / `recovery` / `deprecated`) recorded
   in the `git-secret.opscalehub.io/recipient-roles` annotation.
 - `--keyring FILE` resolves recipients (and roles) from a committed keyring file.
-  `--keyring` also accepts an `http(s)://` URL.
+  `--keyring` also accepts an `http(s)://` URL, and keyring entries may carry an
+  armored `publicKey`.
+- `git-secret-seal ui` — a public-key-only web form for producing GitSecret
+  manifests. Never decrypts, never touches the cluster API, never persists. Run
+  locally (`127.0.0.1:8765`) or in-cluster via the chart's `sealUi.enabled`
+  (reached by `kubectl port-forward`).
 
 ### `git-secret-controller`
 

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -10,6 +10,11 @@ COPY . .
 ARG VERSION=dev
 RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
     -o /out/git-secret-controller ./cmd/git-secret-controller
+# git-secret-seal is bundled too so the chart can run `git-secret-seal ui`
+# (the sealing web form) in-cluster from this same image -- it needs the
+# same gpg runtime and nothing more.
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=${VERSION}" \
+    -o /out/git-secret-seal ./cmd/git-secret-seal
 
 # gpg is a real runtime dependency, not build-time-only -- the
 # controller shells out to it on every reconcile (see internal/gpgutil)
@@ -35,6 +40,7 @@ USER 1000:1000
 WORKDIR /home/git-secret-controller
 
 COPY --from=build /out/git-secret-controller /usr/local/bin/git-secret-controller
+COPY --from=build /out/git-secret-seal /usr/local/bin/git-secret-seal
 
 EXPOSE 8443 8081
 ENTRYPOINT ["/usr/local/bin/git-secret-controller"]

--- a/README.md
+++ b/README.md
@@ -331,6 +331,12 @@ Get the controller's own fingerprint + public key with
 [docs/architecture/keyring.md](docs/architecture/keyring.md) for the keyring
 format and per-environment layout.
 
+Prefer a form to the flags? `git-secret-seal ui` serves a local, public-key-only
+web page for producing manifests (`http://127.0.0.1:8765`); the chart's
+`sealUi.enabled` runs the same thing in-cluster behind `kubectl port-forward`. It
+never decrypts, never touches the cluster API, never persists — see
+[docs/architecture/sealing-console.md](docs/architecture/sealing-console.md).
+
 The generated manifest records the fingerprints it was sealed to in
 `spec.recipients`, so adding or removing a recipient shows up as a one-line
 change in review rather than an opaque blob churn. The controller mirrors this

--- a/charts/git-secret-controller/README.md
+++ b/charts/git-secret-controller/README.md
@@ -101,3 +101,14 @@ optional ways to expose it:
 
 Both are off by default; use either or both. See
 `docs/architecture/keyring.md`.
+
+## Sealing web form (`sealUi.enabled`)
+
+Runs `git-secret-seal ui` in-cluster from the same image: a public-key-only
+web form for producing `GitSecret` manifests. It has
+`automountServiceAccountToken: false` -- it cannot reach the API -- never
+decrypts, and never persists. Reach it with `kubectl port-forward
+svc/<release>-seal-ui 8080:80`; there is no Ingress. `sealUi.keyringConfigMap`
+(optional) names a `ConfigMap` with a `keyring.yaml` (fingerprint + role +
+armored `publicKey`) to pre-fill the recipient picker. See
+`docs/architecture/sealing-console.md`.

--- a/charts/git-secret-controller/templates/seal-ui.yaml
+++ b/charts/git-secret-controller/templates/seal-ui.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.sealUi.enabled }}
+{{- $name := printf "%s-seal-ui" (include "git-secret-controller.fullname" .) }}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: seal-ui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      {{- include "git-secret-controller.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: seal-ui
+  template:
+    metadata:
+      labels:
+        {{- include "git-secret-controller.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: seal-ui
+    spec:
+      # No ServiceAccount token: the UI never talks to the Kubernetes API.
+      automountServiceAccountToken: false
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: seal-ui
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command: ["/usr/local/bin/git-secret-seal"]
+          args:
+            - ui
+            - --addr=:{{ .Values.sealUi.port }}
+            {{- if .Values.sealUi.keyringConfigMap }}
+            - --keyring=/keyring/keyring.yaml
+            {{- end }}
+            {{- if .Values.sealUi.defaultNamespace }}
+            - --namespace={{ .Values.sealUi.defaultNamespace }}
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.sealUi.port }}
+              protocol: TCP
+          readinessProbe:
+            httpGet: { path: /, port: http }
+            initialDelaySeconds: 3
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+            {{- if .Values.sealUi.keyringConfigMap }}
+            - name: keyring
+              mountPath: /keyring
+              readOnly: true
+            {{- end }}
+      volumes:
+        - name: tmp
+          emptyDir: {}
+        {{- if .Values.sealUi.keyringConfigMap }}
+        - name: keyring
+          configMap:
+            name: {{ .Values.sealUi.keyringConfigMap }}
+        {{- end }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: seal-ui
+spec:
+  selector:
+    {{- include "git-secret-controller.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: seal-ui
+  ports:
+    - name: http
+      port: 80
+      targetPort: http
+      protocol: TCP
+{{- end }}

--- a/charts/git-secret-controller/values.yaml
+++ b/charts/git-secret-controller/values.yaml
@@ -64,6 +64,21 @@ publishPublicKey:
   enabled: false
   configMapName: git-secret-controller-pubkey
 
+# A web form for producing GitSecret manifests -- `git-secret-seal ui`, run
+# in-cluster from this same image. Public-key only: it never decrypts,
+# never touches the Kubernetes API, never persists anything; the output is
+# a manifest an operator copies and applies themselves. Reach it with
+# `kubectl port-forward svc/<release>-seal-ui 8080:80` -- no Ingress.
+# keyringConfigMap (optional) names a ConfigMap with a key `keyring.yaml`
+# in the git-secret-seal keyring format (fingerprint + role [+ armored
+# publicKey]) to pre-fill the recipient picker and let sealing work
+# without the operator's own gpg keyring.
+sealUi:
+  enabled: false
+  port: 8080
+  keyringConfigMap: ""
+  defaultNamespace: ""
+
 resources:
   requests:
     cpu: 50m

--- a/cmd/git-secret-seal/keyring.go
+++ b/cmd/git-secret-seal/keyring.go
@@ -23,13 +23,19 @@ import (
 //	recipients:
 //	  - fingerprint: AAAA...   # 40 or 64 hex
 //	    role: controller       # human|controller|recovery|deprecated (optional)
+//	    publicKey: |            # optional armored public key (still not secret)
+//	      -----BEGIN PGP PUBLIC KEY BLOCK-----
+//	      ...
 //	  - fingerprint: BBBB...
 //	    role: recovery
 type keyringFile struct {
-	Recipients []struct {
-		Fingerprint string `json:"fingerprint"`
-		Role        string `json:"role,omitempty"`
-	} `json:"recipients"`
+	Recipients []keyringFileEntry `json:"recipients"`
+}
+
+type keyringFileEntry struct {
+	Fingerprint string `json:"fingerprint"`
+	Role        string `json:"role,omitempty"`
+	PublicKey   string `json:"publicKey,omitempty"`
 }
 
 // loadKeyring reads a keyring from a local path or an http(s):// URL and
@@ -40,13 +46,39 @@ type keyringFile struct {
 // the caller still needs each recipient's public key in their local
 // keyring to actually seal, so a tampered keyring fails closed at seal
 // time rather than leaking anything.
-func loadKeyring(src string) (fingerprints []string, roles map[string]v1alpha1.RecipientRole, err error) {
-	var raw []byte
+func readKeyringBytes(src string) ([]byte, error) {
 	if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
-		raw, err = fetchKeyring(src)
-	} else {
-		raw, err = os.ReadFile(src)
+		return fetchKeyring(src)
 	}
+	return os.ReadFile(src)
+}
+
+// importKeyringPubKeys imports any armored publicKey entries from the
+// keyring at src into the current GNUPGHOME, so server-side sealing works
+// without the operator's own keyring. Entries with no publicKey are
+// skipped silently (they must already be in the keyring).
+func importKeyringPubKeys(src string) error {
+	raw, err := readKeyringBytes(src)
+	if err != nil {
+		return fmt.Errorf("read keyring %s: %w", src, err)
+	}
+	var kr keyringFile
+	if err := sigsyaml.Unmarshal(raw, &kr); err != nil {
+		return fmt.Errorf("parse keyring %s: %w", src, err)
+	}
+	for _, r := range kr.Recipients {
+		if strings.TrimSpace(r.PublicKey) == "" {
+			continue
+		}
+		if err := gpgutil.ImportPublicKey([]byte(r.PublicKey)); err != nil {
+			return fmt.Errorf("import public key for %s: %w", r.Fingerprint, err)
+		}
+	}
+	return nil
+}
+
+func loadKeyring(src string) (fingerprints []string, roles map[string]v1alpha1.RecipientRole, err error) {
+	raw, err := readKeyringBytes(src)
 	if err != nil {
 		return nil, nil, fmt.Errorf("read keyring %s: %w", src, err)
 	}

--- a/cmd/git-secret-seal/main.go
+++ b/cmd/git-secret-seal/main.go
@@ -122,6 +122,9 @@ func run(args []string, stdout, stderr io.Writer) int {
 	if len(args) > 0 && args[0] == "recipients" {
 		return runRecipients(args[1:], stdout, stderr)
 	}
+	if len(args) > 0 && args[0] == "ui" {
+		return runUI(args[1:], stdout, stderr)
+	}
 
 	fs := flag.NewFlagSet("git-secret-seal", flag.ContinueOnError)
 	fs.SetOutput(stderr)

--- a/cmd/git-secret-seal/ui.go
+++ b/cmd/git-secret-seal/ui.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"context"
+	_ "embed"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/signal"
+	"sort"
+	"syscall"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/OpScaleHub/git-secret/api/v1alpha1"
+	"github.com/OpScaleHub/git-secret/internal/gpgutil"
+	"github.com/OpScaleHub/git-secret/internal/sealer"
+)
+
+//go:embed ui.html
+var uiPage []byte
+
+const uiHelp = `git-secret-seal ui - a local web form for producing GitSecret manifests
+
+  git-secret-seal ui [--addr 127.0.0.1:8765] [--keyring FILE|URL] [--namespace NS]
+
+Serves a single-page form: pick recipients, enter key/value pairs, get a
+GitSecret manifest to copy. It is public-key only -- it never decrypts,
+never contacts a cluster, and never persists anything. The sealing runs in
+this process (same trust as running 'git-secret-seal' directly), so run it
+locally, or in-cluster reached only by 'kubectl port-forward'.
+
+  --addr FILE      address to bind (default 127.0.0.1:8765; use :8080 in a pod)
+  --keyring SRC    keyring file or http(s):// URL to pre-fill recipients from;
+                   entries may carry an armored publicKey, imported into an
+                   ephemeral keyring so sealing works without the operator's
+                   own gpg keyring
+  --namespace NS   pre-fill the namespace field
+`
+
+func runUI(args []string, stdout, stderr io.Writer) int {
+	fs := flag.NewFlagSet("git-secret-seal ui", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	addr := fs.String("addr", "127.0.0.1:8765", "address to bind")
+	keyringSrc := fs.String("keyring", "", "keyring file or URL to pre-fill recipients from")
+	namespace := fs.String("namespace", "", "pre-fill the namespace field")
+	if err := fs.Parse(args); err != nil {
+		fmt.Fprint(stderr, uiHelp)
+		return exitUsage
+	}
+	if !gpgutil.Available() {
+		fmt.Fprintln(stderr, "error: gpg binary not found on PATH")
+		return exitError
+	}
+
+	var recips []keyringEntry
+	if *keyringSrc != "" {
+		fps, roles, err := loadKeyring(*keyringSrc)
+		if err != nil {
+			fmt.Fprintln(stderr, "error:", err)
+			return exitError
+		}
+		if err := importKeyringPubKeys(*keyringSrc); err != nil {
+			fmt.Fprintln(stderr, "warning: could not import keyring public keys:", err)
+		}
+		for _, fp := range fps {
+			recips = append(recips, keyringEntry{Fingerprint: fp, Role: string(roles[upperFP(fp)])})
+		}
+		sort.Slice(recips, func(i, j int) bool { return recips[i].Fingerprint < recips[j].Fingerprint })
+	}
+
+	srv := &uiServer{recipients: recips, namespace: *namespace}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", srv.handleIndex)
+	mux.HandleFunc("/api/config", srv.handleConfig)
+	mux.HandleFunc("/api/seal", srv.handleSeal)
+
+	ln, err := net.Listen("tcp", *addr)
+	if err != nil {
+		fmt.Fprintln(stderr, "error: bind", *addr, ":", err)
+		return exitError
+	}
+	httpSrv := &http.Server{Handler: mux, ReadHeaderTimeout: 5 * time.Second}
+
+	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer stop()
+	go func() {
+		<-ctx.Done()
+		sc, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = httpSrv.Shutdown(sc)
+	}()
+
+	fmt.Fprintf(stdout, "git-secret-seal ui  http://%s\n", ln.Addr())
+	if err := httpSrv.Serve(ln); err != nil && err != http.ErrServerClosed {
+		fmt.Fprintln(stderr, "error:", err)
+		return exitError
+	}
+	return exitOK
+}
+
+type keyringEntry struct {
+	Fingerprint string `json:"fingerprint"`
+	Role        string `json:"role,omitempty"`
+}
+
+type uiServer struct {
+	recipients []keyringEntry
+	namespace  string
+}
+
+func (s *uiServer) handleIndex(w http.ResponseWriter, r *http.Request) {
+	if r.URL.Path != "/" {
+		http.NotFound(w, r)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write(uiPage)
+}
+
+func (s *uiServer) handleConfig(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"recipients":       s.recipients,
+		"defaultNamespace": s.namespace,
+	})
+}
+
+type sealRequest struct {
+	Namespace  string            `json:"namespace"`
+	Name       string            `json:"name"`
+	TargetType string            `json:"targetType"`
+	Recipients []keyringEntry    `json:"recipients"`
+	Data       map[string]string `json:"data"`
+}
+
+func (s *uiServer) handleSeal(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		writeJSON(w, http.StatusMethodNotAllowed, map[string]string{"error": "POST only"})
+		return
+	}
+	var req sealRequest
+	if err := json.NewDecoder(io.LimitReader(r.Body, 1<<20)).Decode(&req); err != nil {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "bad JSON: " + err.Error()})
+		return
+	}
+	if req.Namespace == "" || req.Name == "" {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "namespace and name are required"})
+		return
+	}
+	if len(req.Data) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "at least one key/value is required"})
+		return
+	}
+	var fps []string
+	roles := map[string]v1alpha1.RecipientRole{}
+	for _, rc := range req.Recipients {
+		if !gpgutil.ValidFingerprint(rc.Fingerprint) {
+			writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("%q is not a full 40/64-hex GPG fingerprint", rc.Fingerprint)})
+			return
+		}
+		fps = append(fps, rc.Fingerprint)
+		if rc.Role != "" && v1alpha1.ValidRecipientRole(v1alpha1.RecipientRole(rc.Role)) {
+			roles[upperFP(rc.Fingerprint)] = v1alpha1.RecipientRole(rc.Role)
+		}
+	}
+	if len(fps) == 0 {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "at least one recipient is required"})
+		return
+	}
+
+	spec, err := sealer.Seal(req.Namespace, req.Name, req.Data, fps)
+	if err != nil {
+		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
+		return
+	}
+	if req.TargetType != "" {
+		spec.Target.Type = corev1.SecretType(req.TargetType)
+	}
+
+	gs := v1alpha1.GitSecret{}
+	gs.APIVersion = v1alpha1.GroupVersion.Group + "/" + v1alpha1.GroupVersion.Version
+	gs.Kind = "GitSecret"
+	gs.Name = req.Name
+	gs.Namespace = req.Namespace
+	gs.Spec = spec
+	if rs := v1alpha1.FormatRecipientRoles(roles); rs != "" {
+		gs.Annotations = map[string]string{v1alpha1.RecipientRolesAnnotation: rs}
+	}
+
+	out, err := sigsyaml.Marshal(gs)
+	if err != nil {
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "marshal: " + err.Error()})
+		return
+	}
+	writeJSON(w, http.StatusOK, map[string]string{"yaml": string(out)})
+}
+
+func writeJSON(w http.ResponseWriter, code int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
+	_ = json.NewEncoder(w).Encode(v)
+}

--- a/cmd/git-secret-seal/ui.html
+++ b/cmd/git-secret-seal/ui.html
@@ -1,0 +1,133 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>git-secret · seal</title>
+<style>
+  :root{color-scheme:light dark;--bg:#fbfbfa;--fg:#1a1a1a;--muted:#6b6b6b;--line:#e2e2df;--accent:#3a5a40;--card:#fff;--code:#f4f4f2}
+  @media (prefers-color-scheme:dark){:root{--bg:#161615;--fg:#e8e8e6;--muted:#9a9a97;--line:#2e2e2c;--accent:#a3c9a8;--card:#1f1f1d;--code:#141413}}
+  *{box-sizing:border-box}
+  body{margin:0;font:15px/1.5 ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--fg)}
+  main{max-width:760px;margin:0 auto;padding:2rem 1.25rem 4rem}
+  h1{font-size:1.3rem;margin:0 0 .25rem}
+  .sub{color:var(--muted);margin:0 0 1.5rem}
+  fieldset{border:1px solid var(--line);border-radius:10px;margin:0 0 1rem;padding:1rem 1.1rem}
+  legend{padding:0 .4rem;color:var(--muted);font-size:.85rem;text-transform:uppercase;letter-spacing:.04em}
+  label{display:block;font-size:.85rem;color:var(--muted);margin:.6rem 0 .2rem}
+  input,select,textarea{width:100%;padding:.5rem .6rem;border:1px solid var(--line);border-radius:7px;background:var(--card);color:var(--fg);font:inherit}
+  .row{display:grid;grid-template-columns:1fr 1fr auto;gap:.5rem;align-items:end;margin-bottom:.4rem}
+  .row input{margin:0}
+  .rm{background:none;border:1px solid var(--line);border-radius:7px;padding:.5rem .7rem;cursor:pointer;color:var(--muted)}
+  .add{background:none;border:1px dashed var(--line);border-radius:7px;padding:.45rem .8rem;cursor:pointer;color:var(--muted);font:inherit;margin-top:.3rem}
+  .recip{display:flex;gap:.5rem;align-items:center;margin-bottom:.35rem}
+  .recip input{flex:1;font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:.82rem}
+  .recip .role{flex:0 0 130px}
+  button.primary{background:var(--accent);color:#fff;border:0;border-radius:8px;padding:.65rem 1.4rem;font:inherit;font-weight:600;cursor:pointer}
+  @media (prefers-color-scheme:dark){button.primary{color:#161615}}
+  pre{background:var(--code);border:1px solid var(--line);border-radius:9px;padding:1rem;overflow:auto;font:12.5px/1.5 ui-monospace,SFMono-Regular,Menlo,monospace;white-space:pre-wrap;word-break:break-all}
+  .out{margin-top:1.25rem}
+  .out .bar{display:flex;justify-content:space-between;align-items:center;margin-bottom:.4rem}
+  .copy{background:none;border:1px solid var(--line);border-radius:7px;padding:.35rem .8rem;cursor:pointer;color:var(--fg);font:inherit}
+  .err{color:#b3261e;background:#b3261e15;border:1px solid #b3261e40;border-radius:8px;padding:.7rem .9rem;margin-top:1rem;font-size:.9rem}
+  .hint{color:var(--muted);font-size:.82rem;margin-top:.5rem}
+  code{background:var(--code);padding:.1rem .35rem;border-radius:4px;font-size:.85em}
+  .banner{background:var(--accent)15;border:1px solid var(--accent)40;border-radius:8px;padding:.6rem .9rem;font-size:.85rem;margin-bottom:1.5rem;color:var(--muted)}
+</style>
+</head>
+<body>
+<main>
+  <h1>git-secret · seal</h1>
+  <p class="sub">Produce a <code>GitSecret</code> manifest. Public-key only — this page never decrypts, never talks to your cluster, never stores anything.</p>
+  <div class="banner">Review the output, then apply it yourself: <code>kubectl apply -f gitsecret.yaml</code>. Nothing leaves this page until you do.</div>
+
+  <form id="f">
+    <fieldset>
+      <legend>Target</legend>
+      <div style="display:grid;grid-template-columns:1fr 1fr;gap:.6rem">
+        <div><label>Namespace</label><input id="ns" required autocomplete="off"></div>
+        <div><label>Name</label><input id="name" required autocomplete="off"></div>
+      </div>
+      <label>Secret type</label>
+      <input id="type" placeholder="Opaque" autocomplete="off">
+    </fieldset>
+
+    <fieldset>
+      <legend>Recipients <span id="rcount"></span></legend>
+      <div id="recips"></div>
+      <button type="button" class="add" id="addRecip">+ recipient fingerprint</button>
+      <p class="hint">Full 40/64-hex GPG fingerprints. The controller's own fingerprint plus every human who should be able to decrypt. Pre-filled from the keyring if one is configured.</p>
+    </fieldset>
+
+    <fieldset>
+      <legend>Values</legend>
+      <div id="kvs"></div>
+      <button type="button" class="add" id="addKv">+ key / value</button>
+    </fieldset>
+
+    <button type="submit" class="primary">Seal</button>
+  </form>
+
+  <div id="result"></div>
+</main>
+
+<script>
+const $ = s => document.querySelector(s);
+const el = (t,a={},...c) => { const e=document.createElement(t); for(const k in a) e.setAttribute(k,a[k]); c.forEach(x=>e.append(x)); return e; };
+
+function recipRow(fp='', role=''){
+  const inp = el('input',{placeholder:'0000000000000000000000000000000000000000',value:fp});
+  const sel = el('select',{class:'role'});
+  ['','human','controller','recovery','deprecated'].forEach(r=>{
+    const o=el('option',{value:r}); o.textContent = r||'(role)'; if(r===role)o.selected=true; sel.append(o);
+  });
+  const rm = el('button',{type:'button',class:'rm'}); rm.textContent='×';
+  const div = el('div',{class:'recip'}, inp, sel, rm);
+  rm.onclick = () => { div.remove(); updateCount(); };
+  return div;
+}
+function kvRow(k='',v=''){
+  const ki = el('input',{placeholder:'API_KEY',value:k});
+  const vi = el('input',{placeholder:'value',value:v});
+  const rm = el('button',{type:'button',class:'rm'}); rm.textContent='×';
+  const div = el('div',{class:'row'}, el('div',{}, el('label',{},'key'), ki), el('div',{}, el('label',{},'value'), vi), rm);
+  rm.onclick = () => div.remove();
+  return div;
+}
+function updateCount(){ $('#rcount').textContent = '· ' + $('#recips').querySelectorAll('.recip').length; }
+
+$('#addRecip').onclick = () => { $('#recips').append(recipRow()); updateCount(); };
+$('#addKv').onclick = () => $('#kvs').append(kvRow());
+
+fetch('api/config').then(r=>r.json()).then(cfg=>{
+  if(cfg.defaultNamespace) $('#ns').value = cfg.defaultNamespace;
+  (cfg.recipients||[]).forEach(r => $('#recips').append(recipRow(r.fingerprint, r.role||'')));
+  if(!$('#recips').children.length) $('#recips').append(recipRow());
+  updateCount();
+}).catch(()=>{ $('#recips').append(recipRow()); updateCount(); });
+$('#kvs').append(kvRow());
+
+$('#f').onsubmit = async e => {
+  e.preventDefault();
+  $('#result').innerHTML = '';
+  const recipients = [...$('#recips').querySelectorAll('.recip')].map(d=>{
+    const [inp,sel]=d.querySelectorAll('input,select'); return {fingerprint:inp.value.trim(), role:sel.value};
+  }).filter(r=>r.fingerprint);
+  const data = {};
+  for(const d of $('#kvs').querySelectorAll('.row')){
+    const [k,v]=d.querySelectorAll('input'); if(k.value.trim()) data[k.value.trim()] = v.value;
+  }
+  const body = { namespace:$('#ns').value.trim(), name:$('#name').value.trim(), targetType:$('#type').value.trim(), recipients, data };
+  const res = await fetch('api/seal',{method:'POST',headers:{'content-type':'application/json'},body:JSON.stringify(body)});
+  const j = await res.json();
+  if(!res.ok){ $('#result').innerHTML = ''; $('#result').append(el('div',{class:'err'}, j.error||('HTTP '+res.status))); return; }
+  const pre = el('pre',{}, j.yaml);
+  const copy = el('button',{class:'copy'}); copy.textContent='Copy';
+  copy.onclick = () => { navigator.clipboard.writeText(j.yaml); copy.textContent='Copied'; setTimeout(()=>copy.textContent='Copy',1200); };
+  const out = el('div',{class:'out'}, el('div',{class:'bar'}, el('strong',{},'gitsecret.yaml'), copy), pre,
+    el('p',{class:'hint'},'Save it and apply with kubectl, or pipe: pbpaste | kubectl apply -f -'));
+  $('#result').append(out);
+};
+</script>
+</body>
+</html>

--- a/cmd/git-secret-seal/ui_test.go
+++ b/cmd/git-secret-seal/ui_test.go
@@ -1,0 +1,126 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	sigsyaml "sigs.k8s.io/yaml"
+
+	"github.com/OpScaleHub/git-secret/api/v1alpha1"
+	"github.com/OpScaleHub/git-secret/internal/sealer"
+)
+
+func TestUI_ConfigAndSeal(t *testing.T) {
+	home := shortTempDir(t)
+	fpr := genTestKey(t, home)
+	t.Setenv("GNUPGHOME", home)
+
+	srv := &uiServer{
+		recipients: []keyringEntry{{Fingerprint: fpr, Role: "controller"}},
+		namespace:  "demo",
+	}
+
+	// /api/config
+	rec := httptest.NewRecorder()
+	srv.handleConfig(rec, httptest.NewRequest(http.MethodGet, "/api/config", nil))
+	var cfg struct {
+		Recipients       []keyringEntry `json:"recipients"`
+		DefaultNamespace string         `json:"defaultNamespace"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &cfg); err != nil {
+		t.Fatal(err)
+	}
+	if cfg.DefaultNamespace != "demo" || len(cfg.Recipients) != 1 || cfg.Recipients[0].Fingerprint != fpr {
+		t.Fatalf("config = %+v", cfg)
+	}
+
+	// /api/seal happy path
+	body, _ := json.Marshal(sealRequest{
+		Namespace:  "demo",
+		Name:       "app",
+		Recipients: []keyringEntry{{Fingerprint: fpr, Role: "controller"}},
+		Data:       map[string]string{"K": "v"},
+	})
+	rec = httptest.NewRecorder()
+	srv.handleSeal(rec, httptest.NewRequest(http.MethodPost, "/api/seal", bytes.NewReader(body)))
+	if rec.Code != http.StatusOK {
+		t.Fatalf("seal = %d: %s", rec.Code, rec.Body)
+	}
+	var out struct {
+		YAML string `json:"yaml"`
+	}
+	json.Unmarshal(rec.Body.Bytes(), &out)
+	var gs v1alpha1.GitSecret
+	if err := sigsyaml.Unmarshal([]byte(out.YAML), &gs); err != nil {
+		t.Fatalf("output not a GitSecret: %v\n%s", err, out.YAML)
+	}
+	if len(gs.Spec.Recipients) != 1 || gs.Spec.Recipients[0] != fpr {
+		t.Fatalf("recipients = %v", gs.Spec.Recipients)
+	}
+	if v1alpha1.ParseRecipientRoles(gs.Annotations)[fpr] != v1alpha1.RoleController {
+		t.Fatalf("role not recorded: %v", gs.Annotations)
+	}
+	got, err := sealer.Unseal("demo", "app", gs.Spec)
+	if err != nil || got["K"] != "v" {
+		t.Fatalf("UI output does not round-trip: got=%v err=%v", got, err)
+	}
+}
+
+func TestUI_SealRejections(t *testing.T) {
+	home := shortTempDir(t)
+	fpr := genTestKey(t, home)
+	t.Setenv("GNUPGHOME", home)
+	srv := &uiServer{}
+
+	cases := []struct {
+		name string
+		req  any
+		code int
+		msg  string
+	}{
+		{"GET not allowed", nil, http.StatusMethodNotAllowed, "POST only"},
+		{"missing name", sealRequest{Namespace: "n", Recipients: []keyringEntry{{Fingerprint: fpr}}, Data: map[string]string{"K": "v"}}, http.StatusBadRequest, "name are required"},
+		{"no data", sealRequest{Namespace: "n", Name: "x", Recipients: []keyringEntry{{Fingerprint: fpr}}}, http.StatusBadRequest, "key/value is required"},
+		{"bad fpr", sealRequest{Namespace: "n", Name: "x", Recipients: []keyringEntry{{Fingerprint: "DEADBEEF"}}, Data: map[string]string{"K": "v"}}, http.StatusBadRequest, "not a full"},
+		{"no recipients", sealRequest{Namespace: "n", Name: "x", Data: map[string]string{"K": "v"}}, http.StatusBadRequest, "recipient is required"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			method := http.MethodPost
+			var rdr *bytes.Reader
+			if c.req == nil {
+				method = http.MethodGet
+				rdr = bytes.NewReader(nil)
+			} else {
+				b, _ := json.Marshal(c.req)
+				rdr = bytes.NewReader(b)
+			}
+			rec := httptest.NewRecorder()
+			srv.handleSeal(rec, httptest.NewRequest(method, "/api/seal", rdr))
+			if rec.Code != c.code {
+				t.Fatalf("code = %d, want %d (%s)", rec.Code, c.code, rec.Body)
+			}
+			if !strings.Contains(rec.Body.String(), c.msg) {
+				t.Fatalf("body %q missing %q", rec.Body.String(), c.msg)
+			}
+		})
+	}
+}
+
+func TestUI_IndexServesPage(t *testing.T) {
+	srv := &uiServer{}
+	rec := httptest.NewRecorder()
+	srv.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "git-secret") {
+		t.Fatalf("index: %d %q", rec.Code, rec.Body.String()[:min(80, rec.Body.Len())])
+	}
+	rec = httptest.NewRecorder()
+	srv.handleIndex(rec, httptest.NewRequest(http.MethodGet, "/nope", nil))
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("GET /nope = %d, want 404", rec.Code)
+	}
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,8 @@
   webhook enforcing `spec.recipients` and per-namespace required recipients.
 - [provenance.md](architecture/provenance.md) — recording which Git revision
   produced a Secret.
-- [sealing-console.md](architecture/sealing-console.md) — feasibility analysis for
-  a web sealing UI (not scheduled).
+- [sealing-console.md](architecture/sealing-console.md) — `git-secret-seal ui`, a
+  public-key-only web form for producing GitSecret manifests (local or in-cluster).
 
 ## Reporting a vulnerability
 

--- a/docs/architecture/admission-webhook.md
+++ b/docs/architecture/admission-webhook.md
@@ -55,6 +55,25 @@ Manually: run the controller with `--enable-webhook --webhook-service <svc>
 443 → container port 9443 and a `ValidatingWebhookConfiguration` pointing at
 `/validate-git-secret-opscalehub-io-v1alpha1-gitsecret` with an empty `caBundle`.
 
+## Verified live (2026-08-28, k0s v1.36.2)
+
+End-to-end against a real apiserver with the `v0.8.0` controller image and the
+`v0.8.0` CRD, in an isolated namespace with a `namespaceSelector`-scoped
+`ValidatingWebhookConfiguration`:
+
+| Check | Result |
+|---|---|
+| Controller generates + serves its self-signed cert on `:9443` | ✅ `Updated current TLS certificate` |
+| CA injected into the `ValidatingWebhookConfiguration` at runtime | ✅ `injected caBundle` log line |
+| Valid `GitSecret` (recipients match `encryptedKey`) | ✅ admitted, then decrypted into a `Secret` |
+| `spec.recipients` lists 2 fingerprints, blob wrapped to 1 | ✅ **denied**: `spec.recipients does not match encryptedKey: sealer: spec.recipients lists 2 fingerprint(s) but encryptedKey is wrapped to 1 recipient(s)` |
+| Namespace has `git-secret.opscalehub.io/required-recipients` and the object omits one | ✅ **denied**: `namespace "…" requires recipient(s) missing from spec.recipients: …` |
+
+No reconcile hot-loop — an early observation of one was traced to *two*
+controllers (a cluster-wide one plus the isolated test one) both writing the same
+object's status; a single controller settles to `Ready` in one reconcile. Open
+follow-up on live status fields: #65.
+
 ## Not covered
 
 Matching against a full keyring file / `ClusterKeyring` object (only the simpler

--- a/docs/architecture/sealing-console.md
+++ b/docs/architecture/sealing-console.md
@@ -1,66 +1,81 @@
-# Sealing console — feasibility (not scheduled)
+# Sealing console (`git-secret-seal ui`)
 
-Status: **design analysis only.** No console is built or planned. This records the
-thinking so a future decision starts from here instead of from scratch (#46).
+A web form for producing `GitSecret` manifests, for people who would rather not
+drive the `git-secret-seal` CLI — especially non-Linux users. It is **public-key
+only**: it never decrypts, never touches the Kubernetes API, and never persists
+anything. The output is a manifest you review and `kubectl apply` yourself.
 
-## What it would be
+## Run it locally
 
-A web UI for the `git-secret-seal` workflow: pick recipients, enter key/value
-pairs (or paste a `Secret` manifest), see the YAML, get a `GitSecret` manifest
-out. Nothing else.
+```
+git-secret-seal ui                 # http://127.0.0.1:8765
+git-secret-seal ui --keyring envs/prod/keyring.yaml --namespace prod
+```
 
-## What it is not, ever
+Same trust boundary as running `git-secret-seal` directly — the sealing happens
+in the process, using the recipient **public** keys in your gpg keyring (or the
+ones carried in `--keyring`). Nothing leaves your machine.
 
-- **Not a decrypt endpoint.** Sealing is a one-way, public-key-only operation — it
-  needs recipient *public* keys and plaintext input, and produces ciphertext. It
-  never holds or needs a private key.
-- **Not part of `git-secret-controller`.** A separate binary / Deployment, always.
-  Bolting a sealing endpoint onto the always-on process that holds the decrypt
-  key is exactly the trust-domain mixing the CRD design exists to avoid.
-- **Not an authorization point.** The generated manifest still goes through
-  `kubectl apply` / ArgoCD / PR review. The apply path is the control boundary;
-  the console is an authoring convenience.
+## Run it in-cluster
 
-## Deployment shapes
+Helm (`charts/git-secret-controller`):
 
-| Shape | Exposure | Notes |
-|---|---|---|
-| **Local, CLI-launched** (`git-secret-seal ui`, binds `127.0.0.1`, auto-exits) | Lowest — plaintext never leaves the operator's machine | Same trust boundary as running the CLI today |
-| **In-cluster Deployment**, reached by `kubectl port-forward` (no Ingress) | Medium — see risks below | A shared, always-available authoring surface |
-| **In-cluster sidecar / one-shot Job** | Medium | On-demand variant of the above |
+```yaml
+sealUi:
+  enabled: true
+  keyringConfigMap: git-secret-keyring   # optional: pre-fills recipients
+  defaultNamespace: ""
+```
 
-## Residual risks for an in-cluster console, and mitigations
+This deploys a small `Deployment` + `Service` running `git-secret-seal ui` from
+the controller image (the binary is bundled). The pod has
+`automountServiceAccountToken: false` — it genuinely cannot reach the API.
 
-1. **Plaintext in transit / in the pod.** *Mitigation:* do the GPG sealing
-   **client-side in the browser** (WASM OpenPGP). The server then serves only
-   static assets + the recipient public-key list (from the [keyring](keyring.md)),
-   and plaintext never leaves the browser tab. This is the design that makes
-   in-cluster ≈ as safe as local, and is the thing to **prototype first** before
-   committing.
-2. **Recipient substitution** (a compromised console seals to an attacker key
-   too). *Mitigation:* `spec.recipients` is visible in the manifest diff and the
-   manifest goes through review before it means anything.
-3. **Authz** (who may use it, for which namespace). *Mitigation:* not the
-   console's job — the apply path already gates this. Optionally put the
-   port-forward behind the cluster's normal auth proxy.
+Reach it by port-forward — **no Ingress**:
 
-## Hard dependency
+```
+kubectl port-forward svc/git-secret-controller-seal-ui 8080:80
+open http://localhost:8080
+```
 
-Recipient public-key discovery — **done** ([keyring.md](keyring.md):
-`git-secret-controller --print-public-key`, `git-secret-seal --keyring`). A
-console would build its recipient picker on the keyring file.
+### Residual risk, stated plainly
 
-## Recommendation
+Sealing runs in the process, so for the in-cluster deployment the plaintext you
+type travels browser → `kubectl port-forward` tunnel (apiserver-authenticated
+TLS) → the pod, and sits in the pod's memory for the duration of one request. It
+is never written anywhere and never sent to the cluster API. If that transit is
+not acceptable for a given secret, run the UI locally instead, or use the CLI.
 
-**Not worth building now** — there is no demonstrated CLI pain; recent real
-production use went end-to-end on `git-secret-seal` without friction, and
-`--keyring` removes the "retype every fingerprint" annoyance that would have been
-the main driver.
+Doing the GPG work in the browser (WASM OpenPGP) would remove even that transit;
+it is a possible future hardening, not built.
 
-If sealing frequency grows enough that the CLI is a real bottleneck for several
-people, the path is:
+## The keyring
 
-1. Prototype the **local, browser-side-crypto** shape (`git-secret-seal ui`).
-2. Only if a shared surface is genuinely needed, extend the *same* browser-side
-   -crypto build to an in-cluster Deployment behind `port-forward`.
-3. Never a server-side-seal endpoint; never on the controller.
+`keyringConfigMap` names a `ConfigMap` with a `keyring.yaml` key in the
+[keyring format](keyring.md), extended with an optional armored `publicKey` per
+entry:
+
+```yaml
+recipients:
+  - fingerprint: 1111...
+    role: controller
+    publicKey: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      ...
+  - fingerprint: 2222...
+    role: recovery
+    publicKey: |
+      -----BEGIN PGP PUBLIC KEY BLOCK-----
+      ...
+```
+
+The UI imports those public keys into an ephemeral keyring at startup, so
+in-cluster sealing works without any operator keyring. Build the `publicKey`
+blocks with `gpg --armor --export <fpr>` (or, for the controller's own key,
+`git-secret-controller --print-public-key`).
+
+## What it does not do
+
+No decryption. No `kubectl apply`. No cluster API access. No storage. No auth of
+its own — the port-forward (and, if you add one, your cluster's auth proxy) is
+the boundary. It is an authoring convenience, not a control point.

--- a/internal/gpgutil/gpgutil.go
+++ b/internal/gpgutil/gpgutil.go
@@ -172,6 +172,16 @@ func ImportSecretKey(armored []byte) error {
 	return nil
 }
 
+// ImportPublicKey imports an armored public key into the current
+// GNUPGHOME so it can be used as an --encrypt recipient. Public keys are
+// not secret; this is safe to call with keyring-provided material.
+func ImportPublicKey(armored []byte) error {
+	if _, err := run(armored, "--batch", "--import"); err != nil {
+		return fmt.Errorf("gpgutil: import public key: %w", err)
+	}
+	return nil
+}
+
 // ExportPublicKey returns the ASCII-armored public key for fpr from the
 // current GNUPGHOME. Public keys are not secret -- this is used to hand a
 // controller's own public key to whoever needs to seal GitSecrets to it,


### PR DESCRIPTION
Builds the sealing console we agreed on (#46 reopened). **Public-key only** — it
never decrypts, never touches the Kubernetes API, never persists. Output is a
`GitSecret` manifest the operator reviews and `kubectl apply`s themselves.

## `git-secret-seal ui`

New subcommand. Serves one self-contained page (`go:embed`, no external assets) +
`GET /api/config` + `POST /api/seal`. Sealing runs in-process (`sealer.Seal`) —
same trust boundary as the CLI.

```
git-secret-seal ui                                   # http://127.0.0.1:8765
git-secret-seal ui --keyring envs/prod/keyring.yaml --namespace prod
```

Form: namespace / name / type, a recipient list (pre-filled from `--keyring`,
each with a role dropdown), key/value rows. "Seal" → the YAML with a Copy button.

## In-cluster (chart `sealUi.enabled`)

A `Deployment` + `Service` running `git-secret-seal ui` from the controller image
(binary bundled via `Dockerfile.controller`). `automountServiceAccountToken:
false` — it genuinely cannot reach the API. Reached by `kubectl port-forward
svc/<release>-seal-ui 8080:80` — **no Ingress**.

`sealUi.keyringConfigMap` (optional) → a `ConfigMap` with `keyring.yaml`; keyring
entries gained an optional armored `publicKey` so in-cluster sealing works with
no operator keyring.

## Residual risk (documented)

Sealing is in-process, so for the in-cluster deployment plaintext travels
browser → port-forward tunnel (apiserver-authenticated TLS) → pod memory for one
request. Never written, never sent to the API. For anything where that transit
isn't acceptable: run the UI locally, or use the CLI. Browser-side WASM crypto
would remove the transit — noted as future hardening, not built.

## Also in this PR

`docs/architecture/admission-webhook.md` gains a "Verified live (2026-08-28)"
section recording the #55 cluster test results (caBundle injection, accept,
recipient-mismatch deny, namespace-policy deny).

## Tests

`ui_test.go`: config, seal round-trip (output re-`Unseal`s), 5 rejection cases,
index 404. `go build/vet/test` + `helm lint` green.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT