### PR TITLE
fix + pre-freeze hardening: seal-ui read-only-fs, webhook/seal DoS bounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,15 @@
   carries public keys, so the in-cluster deployment works on a read-only root
   filesystem.
 
+### Hardening (pre-freeze audit)
+
+- `git-secret-seal ui` bounds a single `/api/seal` request (key count + total
+  value bytes) to the same limits the sealer enforces per object.
+- `gpgutil.CountRecipients` — the admission-webhook recipient check, which parses
+  the object's attacker-controlled `encryptedKey` — runs under a 5s timeout; the
+  `ValidatingWebhookConfiguration` gets `timeoutSeconds: 10`.
+- `--keyring` URL fetches stop after 3 redirects.
+
 ### Docs
 
 - `docs/architecture/admission-webhook.md` records the live end-to-end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   - `--keyring FILE|URL` pre-fills the recipient picker; keyring entries may carry
     an armored `publicKey` so in-cluster sealing needs no operator keyring.
 - The controller image now bundles the `git-secret-seal` binary.
+- `git-secret-seal ui` sets up its own isolated GNUPGHOME when the keyring
+  carries public keys, so the in-cluster deployment works on a read-only root
+  filesystem.
 
 ### Docs
 

--- a/charts/git-secret-controller/templates/webhook.yaml
+++ b/charts/git-secret-controller/templates/webhook.yaml
@@ -25,6 +25,7 @@ webhooks:
     admissionReviewVersions: ["v1"]
     sideEffects: None
     failurePolicy: {{ .Values.webhook.failurePolicy }}
+    timeoutSeconds: 10
     # caBundle is intentionally omitted: the controller generates a
     # self-signed CA at startup and patches it in here (see
     # internal/webhook.InjectCABundle). Until it does, the apiserver

--- a/cmd/git-secret-seal/keyring.go
+++ b/cmd/git-secret-seal/keyring.go
@@ -53,28 +53,51 @@ func readKeyringBytes(src string) ([]byte, error) {
 	return os.ReadFile(src)
 }
 
-// importKeyringPubKeys imports any armored publicKey entries from the
-// keyring at src into the current GNUPGHOME, so server-side sealing works
-// without the operator's own keyring. Entries with no publicKey are
-// skipped silently (they must already be in the keyring).
-func importKeyringPubKeys(src string) error {
+// keyringHasPublicKeys reports whether the keyring at src carries any
+// armored publicKey blocks (the signal that sealing should run against an
+// isolated keyring rather than the operator's own).
+func keyringHasPublicKeys(src string) (bool, error) {
 	raw, err := readKeyringBytes(src)
 	if err != nil {
-		return fmt.Errorf("read keyring %s: %w", src, err)
+		return false, fmt.Errorf("read keyring %s: %w", src, err)
 	}
 	var kr keyringFile
 	if err := sigsyaml.Unmarshal(raw, &kr); err != nil {
-		return fmt.Errorf("parse keyring %s: %w", src, err)
+		return false, fmt.Errorf("parse keyring %s: %w", src, err)
 	}
+	for _, r := range kr.Recipients {
+		if strings.TrimSpace(r.PublicKey) != "" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// importKeyringPubKeys imports any armored publicKey entries from the
+// keyring at src into the current GNUPGHOME, so server-side sealing works
+// without the operator's own keyring. Entries with no publicKey are
+// skipped silently (they must already be in the keyring). Returns the
+// number imported.
+func importKeyringPubKeys(src string) (int, error) {
+	raw, err := readKeyringBytes(src)
+	if err != nil {
+		return 0, fmt.Errorf("read keyring %s: %w", src, err)
+	}
+	var kr keyringFile
+	if err := sigsyaml.Unmarshal(raw, &kr); err != nil {
+		return 0, fmt.Errorf("parse keyring %s: %w", src, err)
+	}
+	n := 0
 	for _, r := range kr.Recipients {
 		if strings.TrimSpace(r.PublicKey) == "" {
 			continue
 		}
 		if err := gpgutil.ImportPublicKey([]byte(r.PublicKey)); err != nil {
-			return fmt.Errorf("import public key for %s: %w", r.Fingerprint, err)
+			return n, fmt.Errorf("import public key for %s: %w", r.Fingerprint, err)
 		}
+		n++
 	}
-	return nil
+	return n, nil
 }
 
 func loadKeyring(src string) (fingerprints []string, roles map[string]v1alpha1.RecipientRole, err error) {

--- a/cmd/git-secret-seal/keyring.go
+++ b/cmd/git-secret-seal/keyring.go
@@ -137,7 +137,17 @@ func loadKeyring(src string) (fingerprints []string, roles map[string]v1alpha1.R
 }
 
 func fetchKeyring(url string) ([]byte, error) {
-	client := &http.Client{Timeout: 15 * time.Second}
+	client := &http.Client{
+		Timeout: 15 * time.Second,
+		// Cap redirects tightly -- a keyring URL is operator-chosen, but a
+		// misbehaving host shouldn't be able to bounce the fetch around.
+		CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+			if len(via) >= 3 {
+				return fmt.Errorf("stopped after 3 redirects")
+			}
+			return nil
+		},
+	}
 	resp, err := client.Get(url)
 	if err != nil {
 		return nil, err

--- a/cmd/git-secret-seal/keyring_test.go
+++ b/cmd/git-secret-seal/keyring_test.go
@@ -123,3 +123,35 @@ func TestRun_KeyringHTTPError(t *testing.T) {
 		t.Fatal("expected failure on 404 keyring")
 	}
 }
+
+func TestKeyringPublicKeys(t *testing.T) {
+	home := shortTempDir(t)
+	fpr := genTestKey(t, home)
+	t.Setenv("GNUPGHOME", home)
+	pub := exportPublicKeyCLI(t, home, fpr)
+
+	withPub := "recipients:\n  - fingerprint: " + fpr + "\n    role: controller\n    publicKey: |\n"
+	for _, line := range strings.Split(strings.TrimRight(string(pub), "\n"), "\n") {
+		withPub += "      " + line + "\n"
+	}
+	pWith := t.TempDir() + "/with.yaml"
+	os.WriteFile(pWith, []byte(withPub), 0o644)
+
+	pWithout := t.TempDir() + "/without.yaml"
+	os.WriteFile(pWithout, []byte("recipients:\n  - fingerprint: "+fpr+"\n    role: controller\n"), 0o644)
+
+	if has, err := keyringHasPublicKeys(pWith); err != nil || !has {
+		t.Fatalf("keyringHasPublicKeys(with) = %v, %v; want true", has, err)
+	}
+	if has, err := keyringHasPublicKeys(pWithout); err != nil || has {
+		t.Fatalf("keyringHasPublicKeys(without) = %v, %v; want false", has, err)
+	}
+
+	// Import into a fresh keyring works.
+	fresh := shortTempDir(t)
+	t.Setenv("GNUPGHOME", fresh)
+	n, err := importKeyringPubKeys(pWith)
+	if err != nil || n != 1 {
+		t.Fatalf("importKeyringPubKeys = %d, %v; want 1, nil", n, err)
+	}
+}

--- a/cmd/git-secret-seal/ui.go
+++ b/cmd/git-secret-seal/ui.go
@@ -174,6 +174,20 @@ func (s *uiServer) handleSeal(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "at least one key/value is required"})
 		return
 	}
+	// Bound the work a single request can ask for -- matches sealer's own
+	// per-object limits, so a hostile POST can't tie up the process.
+	if len(req.Data) > sealer.MaxEntries {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("too many keys (%d, limit %d)", len(req.Data), sealer.MaxEntries)})
+		return
+	}
+	total := 0
+	for _, v := range req.Data {
+		total += len(v)
+	}
+	if total > sealer.MaxValueBytes {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("values total %d bytes, over the %d limit", total, sealer.MaxValueBytes)})
+		return
+	}
 	var fps []string
 	roles := map[string]v1alpha1.RecipientRole{}
 	for _, rc := range req.Recipients {

--- a/cmd/git-secret-seal/ui.go
+++ b/cmd/git-secret-seal/ui.go
@@ -66,8 +66,25 @@ func runUI(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintln(stderr, "error:", err)
 			return exitError
 		}
-		if err := importKeyringPubKeys(*keyringSrc); err != nil {
-			fmt.Fprintln(stderr, "warning: could not import keyring public keys:", err)
+		// If the keyring carries armored public keys, seal against an
+		// isolated, process-private GNUPGHOME rather than the operator's
+		// own keyring -- this is what makes the in-cluster deployment work
+		// (no operator keyring, read-only root filesystem).
+		if hasPub, _ := keyringHasPublicKeys(*keyringSrc); hasPub {
+			home, err := os.MkdirTemp("", "git-secret-seal-ui-gnupg-")
+			if err != nil {
+				fmt.Fprintln(stderr, "error: create keyring dir:", err)
+				return exitError
+			}
+			_ = os.Chmod(home, 0o700)
+			os.Setenv("GNUPGHOME", home)
+			defer os.RemoveAll(home)
+			if n, err := importKeyringPubKeys(*keyringSrc); err != nil {
+				fmt.Fprintln(stderr, "error: import keyring public keys:", err)
+				return exitError
+			} else {
+				fmt.Fprintf(stdout, "imported %d public key(s) from the keyring into %s\n", n, home)
+			}
 		}
 		for _, fp := range fps {
 			recips = append(recips, keyringEntry{Fingerprint: fp, Role: string(roles[upperFP(fp)])})

--- a/cmd/git-secret-seal/ui_test.go
+++ b/cmd/git-secret-seal/ui_test.go
@@ -124,3 +124,21 @@ func TestUI_IndexServesPage(t *testing.T) {
 		t.Fatalf("GET /nope = %d, want 404", rec.Code)
 	}
 }
+
+func TestUI_SealRejectsOversizedInput(t *testing.T) {
+	home := shortTempDir(t)
+	fpr := genTestKey(t, home)
+	t.Setenv("GNUPGHOME", home)
+	srv := &uiServer{}
+
+	big := map[string]string{}
+	for i := 0; i < 2000; i++ {
+		big[string(rune('a'))+string(rune(i))] = "x"
+	}
+	b, _ := json.Marshal(sealRequest{Namespace: "n", Name: "x", Recipients: []keyringEntry{{Fingerprint: fpr}}, Data: big})
+	rec := httptest.NewRecorder()
+	srv.handleSeal(rec, httptest.NewRequest(http.MethodPost, "/api/seal", bytes.NewReader(b)))
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "too many keys") {
+		t.Fatalf("oversized key count: %d %s", rec.Code, rec.Body)
+	}
+}

--- a/docs/architecture/admission-webhook.md
+++ b/docs/architecture/admission-webhook.md
@@ -71,11 +71,11 @@ End-to-end against a real apiserver with the `v0.8.0` controller image and the
 
 No reconcile hot-loop — an early observation of one was traced to *two*
 controllers (a cluster-wide one plus the isolated test one) both writing the same
-object's status; a single controller settles to `Ready` in one reconcile. Open
-follow-up on live status fields: #65.
+object's status; a single controller settles to `Ready` in one reconcile. The
+live status fields (`recipientCount`, `recipients`, `sourceRevision`) were
+re-checked on a clean single-controller deploy and populate correctly (#65).
 
 ## Not covered
 
 Matching against a full keyring file / `ClusterKeyring` object (only the simpler
-Namespace-annotation form is implemented), and mutating defaults. See #56 for
-keyring-over-HTTP.
+Namespace-annotation form is implemented), and mutating defaults. Keyring-over-HTTP is covered in [keyring.md](keyring.md).

--- a/docs/index.html
+++ b/docs/index.html
@@ -693,7 +693,8 @@ gpg_recipients:
         </div>
       </div>
 
-      <p class="lede" style="margin-top:var(--sp-3)">A container image and Helm chart (<code>charts/git-secret-controller</code>) ship on every tagged release. Full usage — <code>recipients</code>, <code>--rewrap</code>, <code>--keyring</code>, disaster recovery — is in the <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret#gitsecret-crd-git-secret-controller" target="_blank" rel="noopener">README</a> and <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret/tree/main/docs" target="_blank" rel="noopener">docs/</a>.</p>
+      <p class="lede" style="margin-top:var(--sp-3)">Prefer a form to the flags? <code>git-secret-seal ui</code> serves a local, public-key-only web page for producing these manifests — it never decrypts, never touches the cluster, never persists.</p>
+      <p class="lede" style="margin-top:var(--sp-3)">A container image and Helm chart (<code>charts/git-secret-controller</code>) ship on every tagged release. Full usage — <code>recipients</code>, <code>--rewrap</code>, <code>--keyring</code>, the sealing UI, disaster recovery — is in the <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret#gitsecret-crd-git-secret-controller" target="_blank" rel="noopener">README</a> and <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret/tree/main/docs" target="_blank" rel="noopener">docs/</a>.</p>
     </div>
   </section>
 

--- a/docs/security/recipient-lifecycle.md
+++ b/docs/security/recipient-lifecycle.md
@@ -47,7 +47,7 @@ in the manifest and `status.recipients` on the live object
 manifest; commit it and the controller reconciles. Both need a local GPG secret
 key that can already open the object (run them as a current recipient); `add`
 also needs the new fingerprint's public key in your keyring (`gpg --import`, WKD,
-or a keyserver — see #47 for making this discoverable).
+or a keyserver — see [keyring.md](../architecture/keyring.md)).
 
 ## Key expiry
 

--- a/internal/gpgutil/gpgutil.go
+++ b/internal/gpgutil/gpgutil.go
@@ -7,10 +7,12 @@ package gpgutil
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Binary is the gpg executable invoked for every operation.
@@ -206,8 +208,14 @@ func ExportPublicKey(fpr string) ([]byte, error) {
 // encryption-subkey ID, not the primary-key fingerprint -- so this is a
 // count check only (see sealer.VerifyRecipients). --list-packets does not
 // decrypt, so no secret key or agent is required.
+//
+// It runs under a 5s timeout: this parses attacker-controlled input (the
+// GitSecret's encryptedKey) on the admission webhook path, and a crafted
+// packet must not be able to hang the handler.
 func CountRecipients(armored []byte) (int, error) {
-	out, err := run(armored, "--batch", "--list-packets")
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, err := runCtx(ctx, armored, "--batch", "--list-packets")
 	if err != nil {
 		return 0, fmt.Errorf("gpgutil: list-packets: %w", err)
 	}
@@ -226,7 +234,13 @@ func CountRecipients(armored []byte) (int, error) {
 // pinned in .repo-enc.yml), not something gpg's trust model needs to
 // independently vouch for.
 func run(stdin []byte, args ...string) ([]byte, error) {
-	cmd := exec.Command(Binary, args...)
+	return runCtx(context.Background(), stdin, args...)
+}
+
+// runCtx is run with a cancellation/timeout context -- the process is
+// killed if ctx is done before it exits.
+func runCtx(ctx context.Context, stdin []byte, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, Binary, args...)
 	if stdin != nil {
 		cmd.Stdin = bytes.NewReader(stdin)
 	}
@@ -234,6 +248,9 @@ func run(stdin []byte, args ...string) ([]byte, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		if ctx.Err() != nil {
+			return nil, fmt.Errorf("%s timed out: %w", Binary, ctx.Err())
+		}
 		return nil, fmt.Errorf("%v: %s", err, strings.TrimSpace(stderr.String()))
 	}
 	return stdout.Bytes(), nil


### PR DESCRIPTION
## The bug (live-found)

`git-secret-seal ui` in-cluster (from #66) failed on the pod's read-only rootfs:
`gpg: Fatal: can't create directory '/home/.../.gnupg': Read-only file system`.

**Fix:** when the `--keyring` carries armored `publicKey` blocks (the in-cluster
case), the UI creates an isolated process-private `GNUPGHOME` under a temp dir and
imports them there — same pattern the controller/server already use. A `--keyring`
with only fingerprints (the local case) still uses the operator's keyring.

Verified end to end on k0s-homelab: the in-cluster UI seals with **no operator
keyring, read-only fs**, and the manifest **applies and decrypts**.

## Pre-freeze security audit — the minor findings, fixed here

- **`/api/seal` DoS bound.** A single request is now capped at `sealer.MaxEntries`
  keys / `sealer.MaxValueBytes` total, so a hostile POST to a port-forwarded pod
  can't tie up the sealing process.
- **Webhook gpg timeout.** `gpgutil.CountRecipients` parses the GitSecret's
  attacker-controlled `encryptedKey` on the admission path; it now runs under a
  5s timeout (`exec.CommandContext`), and the `ValidatingWebhookConfiguration`
  gets `timeoutSeconds: 10`. A crafted packet can't hang the handler.
- **`--keyring` redirects** capped at 3.

Nothing release-blocking was found; the webhook/UI/pubkey surfaces otherwise
audited clean (XSS-safe HTML — text nodes only; `automountServiceAccountToken:
false` on the UI pod; CA private key never written; least-privilege RBAC).

## Doc audit pass (also here)

- #65 note → "verified" (live status fields populate correctly on a clean
  single-controller deploy — #65 closed).
- Stale `#47`/`#56` refs repointed to `keyring.md`.
- `docs/index.html` mentions `git-secret-seal ui`.
- `CHANGELOG` updated.

`go build/vet/test` + `helm lint` green.

https://claude.ai/code/session_01YHpde5qBkxn6W4M5QTkwZT