### PR TITLE
Controller: harden Beta → GA readiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+### Controller hardening (Beta → GA, #77)
+
+- **Reconcile no longer self-triggers.** The reconciler wrote `status.lastSyncTime`
+  on every pass; that write returned through its own watch and re-enqueued the
+  object, so a steady-state `GitSecret` reconciled forever. Status is now written
+  only when a field other than `lastSyncTime` changes.
+- **Webhook now requires `replicaCount: 1`.** The serving cert is per-pod and the
+  `ValidatingWebhookConfiguration.caBundle` holds one CA; the chart refuses
+  `webhook.enabled` with more than one replica, and the CA injector is
+  leader-gated. Reconcile HA via leader election is unchanged.
+- **Tighter controller RBAC.** Dropped unused verbs (`secrets: delete`,
+  `gitsecrets: update/patch`); scoped `validatingwebhookconfigurations`
+  `update/patch` to the controller's own config by name. New `watchNamespaces`
+  value confines the cache and Secret RBAC to a fixed namespace list
+  (`--watch-namespaces`).
+- New [UPGRADING.md](UPGRADING.md): the `v1alpha1` "additive only" compatibility
+  policy.
+
 ### Deprecations
 
 - **`git-secret-server` (the ESO webhook bridge) is now explicitly deprecated.**

--- a/README.md
+++ b/README.md
@@ -406,6 +406,12 @@ Multi-recipient GPG protects against *loss* of a key. Recovering from a *comprom
 key additionally requires rotating the secret values themselves — see the disaster
 recovery guide.
 
+## Compatibility & upgrades
+
+[UPGRADING.md](UPGRADING.md) is the compatibility contract: versioning, the
+`v1alpha1` "additive only" API policy, and the upgrade/downgrade procedure for
+the `GitSecret` CRD + controller.
+
 ## Publishing & GitHub Pages
 
 The project website is published at: [https://git-secret.opscale.ir](https://git-secret.opscale.ir)

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,58 @@
+# Upgrading git-secret
+
+This document is the compatibility contract. It covers the `GitSecret` CRD +
+`git-secret-controller`; the CLI / Git-hook side is versioned by the same tags but
+has no cluster state to migrate.
+
+## Versioning
+
+Releases are `vMAJOR.MINOR.PATCH`. The project is pre-1.0, so MINOR bumps may
+carry behaviour changes — each one is called out in [CHANGELOG.md](CHANGELOG.md).
+The Helm chart version tracks the release tag; the controller image and chart for
+a given tag are built and tested together and are expected to be deployed
+together.
+
+## The `GitSecret` API
+
+The CRD has one version, `v1alpha1`, and it is both the served and the stored
+version. There is **no conversion webhook** and none is planned while there is a
+single version.
+
+**Compatibility policy for `v1alpha1`:**
+
+- Changes within `v1alpha1` are **additive only** — new optional `spec` / `status`
+  fields, new printer columns, relaxed validation. An object written by an older
+  `git-secret-seal` keeps reconciling unchanged after a controller upgrade.
+- An existing field's meaning, type, or default will **not** change under
+  `v1alpha1`. A change that would require one is introduced as a new version
+  (`v1alpha2` / `v1`) with a conversion path and a migration note here — it will
+  not be a silent break of `v1alpha1`.
+- `spec.encryptedData` / `spec.encryptedKey` are opaque ciphertext produced by
+  `git-secret-seal`; their envelope format is versioned independently inside the
+  blob (`crypto/envelope.go`) and old envelopes stay decryptable — see the
+  "cipher agility" tests in `crypto/`.
+
+**When a new API version is introduced**, this document will gain a section with:
+the field-by-field mapping, whether the conversion is automatic (conversion
+webhook) or a one-time re-seal, and the release in which `v1alpha1` stops being
+served.
+
+## Upgrade procedure
+
+1. `helm upgrade` the chart. The CRD ships with the chart under `crds/`; Helm
+   installs a CRD but does **not** upgrade one it already owns — apply
+   `charts/git-secret-controller/crds/gitsecret.yaml` (or
+   `config/crd/bases/...`) yourself when a release changes it (the CHANGELOG
+   says when).
+2. The controller re-imports its GPG key and re-reconciles every `GitSecret` on
+   start. Target Secrets are owned objects and are re-created if missing.
+3. If you changed `webhook.enabled`, note it requires `replicaCount: 1` (see
+   [docs/architecture/admission-webhook.md](docs/architecture/admission-webhook.md)).
+
+## Downgrade
+
+Additive-only means a downgrade is safe for objects that do not use fields the
+older controller lacks: it ignores unknown `status` fields, and an unknown
+optional `spec` field set by a newer `git-secret-seal` is preserved by the
+apiserver but not acted on. Re-seal with the matching `git-secret-seal` version
+if in doubt.

--- a/api/v1alpha1/gitsecret_types.go
+++ b/api/v1alpha1/gitsecret_types.go
@@ -92,8 +92,12 @@ type GitSecretStatus struct {
 	// +optional
 	SyncedKeys int `json:"syncedKeys,omitempty"`
 
-	// LastSyncTime is when the target Secret was last successfully
-	// written to match this object.
+	// LastSyncTime is when the controller last wrote something for this
+	// object -- created or corrected the target Secret, or moved a status
+	// field. It is not refreshed on a steady-state reconcile where nothing
+	// changed (the controller deliberately skips that write so it does not
+	// re-trigger itself), so it marks the last actual change, not the last
+	// time the object was looked at.
 	// +optional
 	LastSyncTime *metav1.Time `json:"lastSyncTime,omitempty"`
 

--- a/charts/git-secret-controller/templates/deployment.yaml
+++ b/charts/git-secret-controller/templates/deployment.yaml
@@ -37,6 +37,9 @@ spec:
             {{- if .Values.leaderElection.enabled }}
             - --leader-elect
             {{- end }}
+            {{- with .Values.watchNamespaces }}
+            - --watch-namespaces={{ join "," . }}
+            {{- end }}
             {{- if .Values.webhook.enabled }}
             - --enable-webhook
             - --webhook-service={{ include "git-secret-controller.fullname" . }}-webhook

--- a/charts/git-secret-controller/templates/rbac.yaml
+++ b/charts/git-secret-controller/templates/rbac.yaml
@@ -1,53 +1,108 @@
+{{- $fullname := include "git-secret-controller.fullname" . -}}
+{{- $watchNs := .Values.watchNamespaces | default (list) -}}
+{{- $saName := include "git-secret-controller.serviceAccountName" . -}}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "git-secret-controller.fullname" . }}
+  name: {{ $fullname }}
   labels:
     {{- include "git-secret-controller.labels" . | nindent 4 }}
 rules:
+{{- if not $watchNs }}
+  # Cluster-scoped by default: the controller watches GitSecret objects in
+  # every namespace, and a GitSecret in any namespace materialises a Secret
+  # in that same namespace -- so read+write on Secrets is inherently
+  # cluster-wide here, the same footprint sealed-secrets and ESO carry. Set
+  # watchNamespaces in values.yaml to restrict both to a fixed list: the
+  # chart then emits a namespaced Role/RoleBinding per entry instead of
+  # these two rules.
   - apiGroups: ["git-secret.opscalehub.io"]
     resources: ["gitsecrets"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    verbs: ["get", "list", "watch"]
   - apiGroups: ["git-secret.opscalehub.io"]
     resources: ["gitsecrets/status"]
     verbs: ["get", "update", "patch"]
-  # Cluster-scoped: the controller watches GitSecret objects in every
-  # namespace by default (see internal/controller.SetupWithManager),
-  # matching how a target Secret can live in any namespace a GitSecret
-  # names. Scope this down to a Role/RoleBinding per namespace instead
-  # if your cluster needs the controller restricted to specific ones --
-  # not wired up by this chart today.
   - apiGroups: [""]
     resources: ["secrets"]
-    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+    # No "delete": the target Secret is removed by garbage collection via
+    # its owner reference, not by the controller. No non-status write on
+    # gitsecrets either: the reconciler only ever writes the status
+    # subresource.
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+{{- end }}
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create", "patch"]
 {{- if .Values.webhook.enabled }}
   # The webhook reads a target Namespace's required-recipients annotation,
-  # and patches its own self-signed CA into the ValidatingWebhookConfiguration.
+  # and the elected leader patches its own self-signed CA into this one
+  # ValidatingWebhookConfiguration (scoped by name below).
   - apiGroups: [""]
     resources: ["namespaces"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["admissionregistration.k8s.io"]
     resources: ["validatingwebhookconfigurations"]
-    verbs: ["get", "list", "watch", "update", "patch"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["admissionregistration.k8s.io"]
+    resources: ["validatingwebhookconfigurations"]
+    resourceNames: ["{{ $fullname }}"]
+    verbs: ["update", "patch"]
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "git-secret-controller.fullname" . }}
+  name: {{ $fullname }}
   labels:
     {{- include "git-secret-controller.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "git-secret-controller.fullname" . }}
+  name: {{ $fullname }}
 subjects:
   - kind: ServiceAccount
-    name: {{ include "git-secret-controller.serviceAccountName" . }}
+    name: {{ $saName }}
     namespace: {{ .Release.Namespace }}
+{{- range $ns := $watchNs }}
+---
+# watchNamespaces mode: the controller's Secret + GitSecret access is
+# confined to {{ $ns }} (and the other listed namespaces) instead of the
+# whole cluster. Pair with --watch-namespaces on the Deployment, which
+# scopes the informer cache to match.
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "git-secret-controller.labels" $ | nindent 4 }}
+rules:
+  - apiGroups: ["git-secret.opscalehub.io"]
+    resources: ["gitsecrets"]
+    verbs: ["get", "list", "watch"]
+  - apiGroups: ["git-secret.opscalehub.io"]
+    resources: ["gitsecrets/status"]
+    verbs: ["get", "update", "patch"]
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ $fullname }}
+  namespace: {{ $ns }}
+  labels:
+    {{- include "git-secret-controller.labels" $ | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $fullname }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ $saName }}
+    namespace: {{ $.Release.Namespace }}
+{{- end }}
 {{- if .Values.leaderElection.enabled }}
 ---
 # Leader election only needs Lease access in the controller's own
@@ -55,7 +110,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "git-secret-controller.fullname" . }}-leader-election
+  name: {{ $fullname }}-leader-election
   labels:
     {{- include "git-secret-controller.labels" . | nindent 4 }}
 rules:
@@ -69,15 +124,15 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "git-secret-controller.fullname" . }}-leader-election
+  name: {{ $fullname }}-leader-election
   labels:
     {{- include "git-secret-controller.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "git-secret-controller.fullname" . }}-leader-election
+  name: {{ $fullname }}-leader-election
 subjects:
   - kind: ServiceAccount
-    name: {{ include "git-secret-controller.serviceAccountName" . }}
+    name: {{ $saName }}
     namespace: {{ .Release.Namespace }}
 {{- end }}

--- a/charts/git-secret-controller/templates/seal-ui.yaml
+++ b/charts/git-secret-controller/templates/seal-ui.yaml
@@ -31,6 +31,7 @@ spec:
           args:
             - ui
             - --addr=:{{ .Values.sealUi.port }}
+            - --max-inflight={{ .Values.sealUi.maxInflight }}
             {{- if .Values.sealUi.keyringConfigMap }}
             - --keyring=/keyring/keyring.yaml
             {{- end }}
@@ -81,4 +82,46 @@ spec:
       port: 80
       targetPort: http
       protocol: TCP
+{{- if .Values.sealUi.networkPolicy.enabled }}
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $name }}
+  labels:
+    {{- include "git-secret-controller.labels" . | nindent 4 }}
+    app.kubernetes.io/component: seal-ui
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "git-secret-controller.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: seal-ui
+  policyTypes:
+    - Egress
+    {{- if .Values.sealUi.networkPolicy.allowFrom }}
+    - Ingress
+    {{- end }}
+  # The seal-UI needs no egress at serving time -- it never calls the
+  # Kubernetes API and its keyring is a mounted ConfigMap. Allow DNS only.
+  egress:
+    - to:
+        - namespaceSelector: {}
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
+  {{- with .Values.sealUi.networkPolicy.allowFrom }}
+  # Ingress restriction is opt-in: leaving allowFrom empty keeps the
+  # Service reachable by `kubectl port-forward` and the kubelet probe
+  # (whose source a NetworkPolicy cannot easily select). Set it when you
+  # front the UI some other way.
+  ingress:
+    - from:
+        {{- toYaml . | nindent 8 }}
+      ports:
+        - protocol: TCP
+          port: {{ $.Values.sealUi.port }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/charts/git-secret-controller/templates/webhook.yaml
+++ b/charts/git-secret-controller/templates/webhook.yaml
@@ -1,4 +1,7 @@
 {{- if .Values.webhook.enabled }}
+{{- if gt (int .Values.replicaCount) 1 }}
+{{- fail "webhook.enabled requires replicaCount: 1. The controller mints its own self-signed webhook serving cert per pod and the ValidatingWebhookConfiguration.caBundle holds exactly one, so with >1 replica the apiserver rejects admission calls routed to any pod whose cert isn't the published one. Run a single replica while the webhook is on (reconcile still recovers on restart), or terminate the webhook cert with cert-manager (not wired by this chart yet)." }}
+{{- end }}
 apiVersion: v1
 kind: Service
 metadata:

--- a/charts/git-secret-controller/values.yaml
+++ b/charts/git-secret-controller/values.yaml
@@ -13,6 +13,15 @@ fullnameOverride: ""
 
 replicaCount: 1
 
+# By default the controller watches GitSecrets in every namespace and is
+# granted cluster-wide read+write on Secrets to do it (a GitSecret in any
+# namespace materialises a Secret in that same namespace). To confine it,
+# list the namespaces here: the chart then generates a namespaced
+# Role/RoleBinding per entry instead of the cluster-wide Secret grant, and
+# passes --watch-namespaces so the informer cache matches. Leave empty for
+# cluster-wide.
+watchNamespaces: []
+
 # Required. This controller's own dedicated GPG identity -- the
 # recipient every GitSecret it should be able to decrypt must be sealed
 # to. Generate with `gpg --batch --passphrase '' --quick-generate-key`,

--- a/charts/git-secret-controller/values.yaml
+++ b/charts/git-secret-controller/values.yaml
@@ -94,6 +94,19 @@ sealUi:
   port: 8080
   keyringConfigMap: ""
   defaultNamespace: ""
+  # Cap on concurrent /api/seal requests -- each forks gpg. Excess
+  # requests get HTTP 429. The in-cluster deployment has no auth of its
+  # own (it is reached by port-forward), so this bounds a burst from any
+  # pod that can route to the Service.
+  maxInflight: 4
+  networkPolicy:
+    # Locks egress to DNS only (the UI needs no egress at serving time).
+    enabled: true
+    # Optional ingress restriction. Empty keeps the Service reachable by
+    # `kubectl port-forward` and the kubelet readiness probe (whose
+    # sources a NetworkPolicy cannot select). Set a list of
+    # NetworkPolicyPeer objects if you front the UI another way.
+    allowFrom: []
 
 resources:
   requests:

--- a/charts/git-secret-controller/values.yaml
+++ b/charts/git-secret-controller/values.yaml
@@ -36,12 +36,19 @@ healthProbe:
 
 # Validating admission webhook for GitSecret objects. When enabled, the
 # controller rejects a GitSecret whose spec.recipients disagrees with its
-# encryptedKey, and enforces any per-namespace required-recipient set (the
+# encryptedKey (a count check -- see threat-model T11), and enforces any
+# per-namespace required-recipient set (the
 # git-secret.opscalehub.io/required-recipients Namespace annotation). The
-# controller generates its own self-signed serving cert at startup and
-# injects the CA into the ValidatingWebhookConfiguration -- no cert-manager
-# needed. Leave failurePolicy at Fail: the whole point is to block
-# non-conforming objects, and admission is not the decrypt path.
+# controller generates its own self-signed serving cert at startup and the
+# elected leader injects the CA into the ValidatingWebhookConfiguration --
+# no cert-manager needed. Leave failurePolicy at Fail: the whole point is
+# to block non-conforming objects, and admission is not the decrypt path.
+#
+# Requires replicaCount: 1. The serving cert is per-pod and the
+# ValidatingWebhookConfiguration.caBundle holds one CA, so a multi-replica
+# webhook needs a shared cert (cert-manager) that this chart does not wire
+# up yet -- the chart refuses `webhook.enabled` with replicaCount > 1.
+# Reconcile itself is unaffected and recovers on restart.
 webhook:
   enabled: false
   port: 9443

--- a/cmd/git-secret-controller/main.go
+++ b/cmd/git-secret-controller/main.go
@@ -22,6 +22,7 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
@@ -54,6 +55,7 @@ func run(args []string, environ []string) int {
 	metricsAddr := fs.String("metrics-bind-address", ":8443", "address the metrics endpoint binds to (env METRICS_BIND_ADDRESS)")
 	healthAddr := fs.String("health-probe-bind-address", ":8081", "address the liveness/readiness probe endpoint binds to (env HEALTH_PROBE_BIND_ADDRESS)")
 	leaderElect := fs.Bool("leader-elect", false, "enable leader election so only one replica reconciles at a time (env LEADER_ELECT)")
+	watchNamespaces := fs.String("watch-namespaces", "", "comma-separated namespaces to confine the cache and reconciler to (env WATCH_NAMESPACES); empty watches all namespaces")
 	gpgPrivateKeyFile := fs.String("gpg-private-key-file", "", "path to this controller's armored GPG private key, imported at startup (env GPG_PRIVATE_KEY_FILE)")
 	printPublicKey := fs.Bool("print-public-key", false, "import the key, print its fingerprint and armored PUBLIC key to stdout, and exit (for handing to whoever seals GitSecrets to this controller)")
 	enableWebhook := fs.Bool("enable-webhook", false, "serve the GitSecret validating admission webhook (env ENABLE_WEBHOOK)")
@@ -160,6 +162,15 @@ func run(args []string, environ []string) int {
 		HealthProbeBindAddress: *healthAddr,
 		LeaderElection:         *leaderElect,
 		LeaderElectionID:       "git-secret-controller.git-secret.opscalehub.io",
+	}
+
+	if nsList := parseWatchNamespaces(firstNonEmpty(*watchNamespaces, env["WATCH_NAMESPACES"])); len(nsList) > 0 {
+		defaults := make(map[string]cache.Config, len(nsList))
+		for _, ns := range nsList {
+			defaults[ns] = cache.Config{}
+		}
+		mgrOpts.Cache = cache.Options{DefaultNamespaces: defaults}
+		setupLog.Info("cache confined to namespaces", "namespaces", nsList)
 	}
 
 	var webhookCerts *gswebhook.Certs
@@ -307,4 +318,17 @@ func firstNonEmpty(vals ...string) string {
 		}
 	}
 	return ""
+}
+
+// parseWatchNamespaces splits a comma-separated namespace list, trimming
+// spaces and dropping empties. An empty or all-blank input returns nil,
+// which the caller treats as "watch every namespace".
+func parseWatchNamespaces(csv string) []string {
+	var out []string
+	for _, n := range strings.Split(csv, ",") {
+		if n = strings.TrimSpace(n); n != "" {
+			out = append(out, n)
+		}
+	}
+	return out
 }

--- a/cmd/git-secret-controller/main_test.go
+++ b/cmd/git-secret-controller/main_test.go
@@ -15,6 +15,33 @@ import (
 	"github.com/OpScaleHub/git-secret/internal/gpgutil"
 )
 
+func TestParseWatchNamespaces(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"", nil},
+		{"   ", nil},
+		{",", nil},
+		{"prod", []string{"prod"}},
+		{"prod,staging", []string{"prod", "staging"}},
+		{" prod , , staging ,", []string{"prod", "staging"}},
+	}
+	for _, c := range cases {
+		got := parseWatchNamespaces(c.in)
+		if len(got) != len(c.want) {
+			t.Errorf("parseWatchNamespaces(%q) = %v, want %v", c.in, got, c.want)
+			continue
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Errorf("parseWatchNamespaces(%q) = %v, want %v", c.in, got, c.want)
+				break
+			}
+		}
+	}
+}
+
 // TestPrintPublicKey exercises the --print-public-key path, which imports
 // the configured private key and prints only its fingerprint + armored
 // PUBLIC key, without ever contacting a cluster.

--- a/cmd/git-secret-seal/ui.go
+++ b/cmd/git-secret-seal/ui.go
@@ -36,13 +36,22 @@ never contacts a cluster, and never persists anything. The sealing runs in
 this process (same trust as running 'git-secret-seal' directly), so run it
 locally, or in-cluster reached only by 'kubectl port-forward'.
 
-  --addr FILE      address to bind (default 127.0.0.1:8765; use :8080 in a pod)
-  --keyring SRC    keyring file or http(s):// URL to pre-fill recipients from;
-                   entries may carry an armored publicKey, imported into an
-                   ephemeral keyring so sealing works without the operator's
-                   own gpg keyring
-  --namespace NS   pre-fill the namespace field
+  --addr FILE          address to bind (default 127.0.0.1:8765; use :8080 in a pod)
+  --keyring SRC        keyring file or http(s):// URL to pre-fill recipients from;
+                       entries may carry an armored publicKey, imported into an
+                       ephemeral keyring so sealing works without the operator's
+                       own gpg keyring
+  --namespace NS       pre-fill the namespace field
+  --max-inflight N     cap concurrent /api/seal requests (each forks gpg);
+                       excess requests get 429 (default 4)
 `
+
+// maxSealRecipients bounds how many recipients one /api/seal request may
+// name, matching the GitSecret CRD's spec.recipients MaxItems.
+const maxSealRecipients = 64
+
+// sealTimeout bounds a single gpg wrap on the request path.
+const sealTimeout = 30 * time.Second
 
 func runUI(args []string, stdout, stderr io.Writer) int {
 	fs := flag.NewFlagSet("git-secret-seal ui", flag.ContinueOnError)
@@ -50,6 +59,7 @@ func runUI(args []string, stdout, stderr io.Writer) int {
 	addr := fs.String("addr", "127.0.0.1:8765", "address to bind")
 	keyringSrc := fs.String("keyring", "", "keyring file or URL to pre-fill recipients from")
 	namespace := fs.String("namespace", "", "pre-fill the namespace field")
+	maxInflight := fs.Int("max-inflight", 4, "cap concurrent /api/seal requests")
 	if err := fs.Parse(args); err != nil {
 		fmt.Fprint(stderr, uiHelp)
 		return exitUsage
@@ -92,7 +102,7 @@ func runUI(args []string, stdout, stderr io.Writer) int {
 		sort.Slice(recips, func(i, j int) bool { return recips[i].Fingerprint < recips[j].Fingerprint })
 	}
 
-	srv := &uiServer{recipients: recips, namespace: *namespace}
+	srv := newUIServer(recips, *namespace, *maxInflight)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/", srv.handleIndex)
 	mux.HandleFunc("/api/config", srv.handleConfig)
@@ -130,6 +140,20 @@ type keyringEntry struct {
 type uiServer struct {
 	recipients []keyringEntry
 	namespace  string
+	// sealSlots is a counting semaphore: each /api/seal forks gpg, so a
+	// burst of unauthenticated requests (the in-cluster deployment has no
+	// auth of its own) could otherwise spawn unbounded processes. A full
+	// channel means "at capacity" -> 429. Nil disables the cap.
+	sealSlots chan struct{}
+}
+
+// newUIServer builds a uiServer with a concurrency cap of maxInflight
+// (clamped to >= 1) on /api/seal.
+func newUIServer(recips []keyringEntry, namespace string, maxInflight int) *uiServer {
+	if maxInflight < 1 {
+		maxInflight = 1
+	}
+	return &uiServer{recipients: recips, namespace: namespace, sealSlots: make(chan struct{}, maxInflight)}
 }
 
 func (s *uiServer) handleIndex(w http.ResponseWriter, r *http.Request) {
@@ -204,8 +228,25 @@ func (s *uiServer) handleSeal(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusBadRequest, map[string]string{"error": "at least one recipient is required"})
 		return
 	}
+	if len(fps) > maxSealRecipients {
+		writeJSON(w, http.StatusBadRequest, map[string]string{"error": fmt.Sprintf("too many recipients (%d, limit %d)", len(fps), maxSealRecipients)})
+		return
+	}
 
-	spec, err := sealer.Seal(req.Namespace, req.Name, req.Data, fps)
+	// Bound concurrency (each seal forks gpg) and per-request runtime.
+	if s.sealSlots != nil {
+		select {
+		case s.sealSlots <- struct{}{}:
+			defer func() { <-s.sealSlots }()
+		default:
+			writeJSON(w, http.StatusTooManyRequests, map[string]string{"error": "server busy, retry shortly"})
+			return
+		}
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), sealTimeout)
+	defer cancel()
+
+	spec, err := sealer.SealContext(ctx, req.Namespace, req.Name, req.Data, fps)
 	if err != nil {
 		writeJSON(w, http.StatusUnprocessableEntity, map[string]string{"error": err.Error()})
 		return

--- a/cmd/git-secret-seal/ui_test.go
+++ b/cmd/git-secret-seal/ui_test.go
@@ -125,6 +125,57 @@ func TestUI_IndexServesPage(t *testing.T) {
 	}
 }
 
+// TestUI_SealConcurrencyCap pins #77 item 7: /api/seal forks gpg, so
+// concurrent requests are bounded and the overflow gets 429 rather than
+// spawning unbounded processes.
+func TestUI_SealConcurrencyCap(t *testing.T) {
+	srv := newUIServer(nil, "", 1)
+	// Occupy the single slot, as an in-flight seal would.
+	srv.sealSlots <- struct{}{}
+
+	fpr := strings.Repeat("A", 40)
+	body, _ := json.Marshal(sealRequest{
+		Namespace:  "n",
+		Name:       "x",
+		Recipients: []keyringEntry{{Fingerprint: fpr}},
+		Data:       map[string]string{"K": "v"},
+	})
+	rec := httptest.NewRecorder()
+	srv.handleSeal(rec, httptest.NewRequest(http.MethodPost, "/api/seal", bytes.NewReader(body)))
+	if rec.Code != http.StatusTooManyRequests {
+		t.Fatalf("at-capacity seal = %d, want 429 (%s)", rec.Code, rec.Body)
+	}
+	if !strings.Contains(rec.Body.String(), "busy") {
+		t.Fatalf("429 body = %q", rec.Body.String())
+	}
+
+	// Free the slot; a request now gets past the semaphore (and fails
+	// later, on gpg, because "AAA..." isn't a real key -- that's fine,
+	// we're only checking it's no longer 429).
+	<-srv.sealSlots
+	rec = httptest.NewRecorder()
+	srv.handleSeal(rec, httptest.NewRequest(http.MethodPost, "/api/seal", bytes.NewReader(body)))
+	if rec.Code == http.StatusTooManyRequests {
+		t.Fatalf("seal still 429 after slot freed")
+	}
+}
+
+// TestUI_SealRejectsTooManyRecipients pins the recipient cap added for #77
+// item 7 (matches the CRD's spec.recipients MaxItems).
+func TestUI_SealRejectsTooManyRecipients(t *testing.T) {
+	srv := newUIServer(nil, "", 4)
+	recips := make([]keyringEntry, maxSealRecipients+1)
+	for i := range recips {
+		recips[i] = keyringEntry{Fingerprint: strings.Repeat("A", 40)}
+	}
+	body, _ := json.Marshal(sealRequest{Namespace: "n", Name: "x", Recipients: recips, Data: map[string]string{"K": "v"}})
+	rec := httptest.NewRecorder()
+	srv.handleSeal(rec, httptest.NewRequest(http.MethodPost, "/api/seal", bytes.NewReader(body)))
+	if rec.Code != http.StatusBadRequest || !strings.Contains(rec.Body.String(), "too many recipients") {
+		t.Fatalf("too many recipients: %d %s", rec.Code, rec.Body)
+	}
+}
+
 func TestUI_SealRejectsOversizedInput(t *testing.T) {
 	home := shortTempDir(t)
 	fpr := genTestKey(t, home)

--- a/docs/architecture/admission-webhook.md
+++ b/docs/architecture/admission-webhook.md
@@ -35,6 +35,17 @@ controller injecting the CA, during which — with `failurePolicy: Fail` —
 `GitSecret` writes are rejected. That is the safe direction, and it clears within
 seconds of the controller becoming ready.
 
+**Requires `replicaCount: 1`.** The serving cert is per-pod and the
+`ValidatingWebhookConfiguration.caBundle` holds exactly one CA — the elected
+leader injects its own. Run more than one replica and the apiserver load-balances
+admission calls across pods whose certs the published CA does not vouch for, so
+`failurePolicy: Fail` rejects a fraction of `GitSecret` writes. The CA injector is
+leader-gated (`internal/webhook.caBundleInjector`) so a mis-scaled deployment is
+not also a write-storm on the cluster-scoped config, and the chart refuses
+`webhook.enabled` with `replicaCount > 1` outright. Multi-replica webhook HA needs
+a shared cert (cert-manager); reconcile HA via leader election is unaffected and
+does not need the webhook. See [#77](https://github.com/OpScaleHub/git-secret/issues/77).
+
 ## Enabling it
 
 Helm:
@@ -71,9 +82,12 @@ End-to-end against a real apiserver with the `v0.8.0` controller image and the
 
 No reconcile hot-loop — an early observation of one was traced to *two*
 controllers (a cluster-wide one plus the isolated test one) both writing the same
-object's status; a single controller settles to `Ready` in one reconcile. The
-live status fields (`recipientCount`, `recipients`, `sourceRevision`) were
-re-checked on a clean single-controller deploy and populate correctly (#65).
+object's status. A single controller settles to `Ready` and then stops: as of
+[#77](https://github.com/OpScaleHub/git-secret/issues/77) the reconciler only
+writes status when a field other than `lastSyncTime` actually changes, so its own
+status write no longer re-enqueues it. The live status fields (`recipientCount`,
+`recipients`, `sourceRevision`) were re-checked on a clean single-controller
+deploy and populate correctly (#65).
 
 ## Not covered
 

--- a/docs/architecture/overview.md
+++ b/docs/architecture/overview.md
@@ -48,6 +48,15 @@ No repo clone, no SSH, no outbound network call on the decrypt path — the
 ciphertext arrives as part of the object via the same apply path as every other
 manifest.
 
+**On failure the target Secret is left as it was.** If a reconcile cannot unseal
+the object — wrong key, expired recipient, a rewrap that dropped the controller —
+the controller sets `Ready=False` / `UnsealFailed` and stops; it does **not**
+delete or blank the Secret it last wrote. That is deliberate (a transient GPG
+problem must not take a running workload's secret away), and it is not an access
+leak: who can read the plaintext Secret is Kubernetes RBAC on that namespace, not
+the GitSecret's recipient list. To actually remove the Secret, delete the
+`GitSecret` — garbage collection takes the owned Secret with it.
+
 ## Envelope: two layers
 
 ```

--- a/docs/architecture/sealing-console.md
+++ b/docs/architecture/sealing-console.md
@@ -49,6 +49,16 @@ not acceptable for a given secret, run the UI locally instead, or use the CLI.
 Doing the GPG work in the browser (WASM OpenPGP) would remove even that transit;
 it is a possible future hardening, not built.
 
+**In-cluster reachability.** The UI has no auth of its own, so `kubectl
+port-forward` is not the only path to it — any pod that can route to the
+ClusterIP `Service` can `POST /api/seal`. The blast radius is bounded (public-key
+only, nothing decrypted, nothing persisted, the caller cannot apply the manifest
+they get back), so this is availability, not confidentiality: the chart caps
+concurrent `/api/seal` at `sealUi.maxInflight` (excess → HTTP 429) and each seal
+runs under a 30s deadline, and ships a `NetworkPolicy` that locks egress to DNS.
+Restrict ingress too with `sealUi.networkPolicy.allowFrom` if you do not want
+every pod in the cluster able to reach it.
+
 ## The keyring
 
 `keyringConfigMap` names a `ConfigMap` with a `keyring.yaml` key in the
@@ -77,5 +87,7 @@ blocks with `gpg --armor --export <fpr>` (or, for the controller's own key,
 ## What it does not do
 
 No decryption. No `kubectl apply`. No cluster API access. No storage. No auth of
-its own — the port-forward (and, if you add one, your cluster's auth proxy) is
-the boundary. It is an authoring convenience, not a control point.
+its own — the port-forward (and, if you add one, your cluster's auth proxy or an
+ingress `NetworkPolicy`) is the boundary. It is an authoring convenience, not a
+control point: what reaches the cluster is still gated by whoever applies the
+manifest.

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -81,7 +81,7 @@ Notation: **L** = availability/recovery, **C** = confidentiality, **I** = integr
 | T8 | Malicious cluster administrator | C | **Out of scope.** Anyone who can `kubectl get secret -o yaml` wins without touching `git-secret`. |
 | T9 | Compromised controller pod | C | Blast radius = `GitSecret`s wrapped to the controller key. Mitigation: don't wrap every object to every controller — per-cluster / per-env recipient sets ([multi-cluster.md](../architecture/multi-cluster.md)); `runAsNonRoot`, read-only rootfs, minimal RBAC. |
 | T10 | Rollback / history-rewrite of a `GitSecret` in Git | I | **Observable, not yet prevented.** `git-secret-seal` stamps `source-revision` and the controller mirrors it to `status.sourceRevision` (a `Revision` printer column), so a rollback is visible ([provenance.md](../architecture/provenance.md)). Refusing to go below an expected revision is a separate design question. |
-| T11 | Recipient substitution — object sealed to an attacker key alongside the real ones | C | **Handled** (review + optional enforcement). `spec.recipients` lists the fingerprints on the object (one-line diff in review); the optional [validating webhook](../architecture/admission-webhook.md) rejects a `GitSecret` whose `spec.recipients` count disagrees with the blob, and enforces a per-namespace required-recipient set. Without the webhook it is still a controller warning. |
+| T11 | Recipient substitution — object sealed to an attacker key alongside the real ones | C | **Partial (review aid + count check).** `spec.recipients` lists the fingerprints on the object (a one-line diff in review), and the optional [validating webhook](../architecture/admission-webhook.md) rejects a `GitSecret` whose `spec.recipients` *count* disagrees with the blob, plus enforces a per-namespace required-recipient set. It is **not** cryptographic authentication of the set: `--list-packets` exposes encryption-subkey IDs, not primary fingerprints, so a substitution that keeps the count constant (seal to `[controller, attacker]`, list `[controller, human]`) passes both the webhook and a casual diff read. Real per-fingerprint verification is #40 (see invariant #9). |
 | T12 | Pre-existing target `Secret` silently adopted & cleared | I | **Handled.** A colliding `Secret` this `GitSecret` does not own is left untouched and a `TargetConflict` Ready=False condition is set, unless the operator opts in with `spec.target.adopt`. Tests `TestReconcile_DoesNotClobberUnownedSecret` / `_AdoptsUnownedSecretWhenOptedIn`. |
 | T13 | Plaintext committed to Git (CLI path) | C | **Handled.** `verify` + the `pre-push` hook fail closed; `SECRETIZE_SKIP_HOOKS` is opt-in per-invocation, never tied to ambient `CI`. |
 | T14 | Recipient specified as a short key ID / email, resolving to the wrong key | C | **Handled.** `gpgutil.ValidFingerprint` requires a full 40/64-hex fingerprint everywhere recipients are accepted. |
@@ -110,8 +110,11 @@ regression regardless of the feature it enables.
    master key and cannot enumerate or open objects sealed to other identities.
 8. **`git-secret-seal` never writes plaintext to disk** beyond what the caller
    passed in.
-9. **Recipient changes are reviewable** — visible in the Git diff of the object,
-   not buried in an opaque re-encrypted blob. *(Depends on #40.)*
+9. **Recipient changes are reviewable** — the declared set (`spec.recipients`) is
+   visible in the Git diff of the object, not buried in an opaque re-encrypted
+   blob. This is a review aid, not proof: the declared set is self-asserted and
+   only *count*-checked against the blob (T11). Cryptographic per-fingerprint
+   verification is *(#40)*.
 10. **The apply path, not any authoring tool, is the authorization boundary** for
     what reaches the cluster.
 

--- a/internal/controller/gitsecret_controller.go
+++ b/internal/controller/gitsecret_controller.go
@@ -8,6 +8,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	"slices"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,6 +55,14 @@ func (r *GitSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		return ctrl.Result{}, fmt.Errorf("get GitSecret: %w", err)
 	}
 
+	// Snapshot the status as it stands in etcd. Every status write below
+	// is gated on this actually changing something meaningful: an
+	// unconditional Status().Update returns straight back through this
+	// controller's own GitSecret watch as an Update event and re-enqueues
+	// the object, so a per-reconcile timestamp bump would reconcile the
+	// object forever (once per watch round-trip, one etcd write each).
+	origStatus := gs.Status.DeepCopy()
+
 	targetName := gs.Spec.Target.Name
 	if targetName == "" {
 		targetName = gs.Name
@@ -77,7 +86,7 @@ func (r *GitSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if unsealErr != nil {
 		logger.Error(unsealErr, "unseal failed", "gitsecret", req.NamespacedName)
 		r.setCondition(&gs, metav1.ConditionFalse, "UnsealFailed", unsealErr.Error())
-		if statusErr := r.Status().Update(ctx, &gs); statusErr != nil {
+		if statusErr := r.persistStatus(ctx, &gs, origStatus); statusErr != nil {
 			logger.Error(statusErr, "failed to record UnsealFailed status")
 		}
 		// Do not requeue tightly on a decrypt failure -- it will not
@@ -105,7 +114,7 @@ func (r *GitSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 			msg := fmt.Sprintf("Secret/%s already exists and is not managed by this GitSecret; set spec.target.adopt to take it over", targetName)
 			logger.Info("target Secret conflict", "gitsecret", req.NamespacedName, "secret", targetName)
 			r.setCondition(&gs, metav1.ConditionFalse, "TargetConflict", msg)
-			if statusErr := r.Status().Update(ctx, &gs); statusErr != nil {
+			if statusErr := r.persistStatus(ctx, &gs, origStatus); statusErr != nil {
 				logger.Error(statusErr, "failed to record TargetConflict status")
 			}
 			return ctrl.Result{}, nil
@@ -154,25 +163,68 @@ func (r *GitSecretReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	if err != nil {
 		logger.Error(err, "failed to create/update target Secret")
 		r.setCondition(&gs, metav1.ConditionFalse, "ApplyFailed", err.Error())
-		if statusErr := r.Status().Update(ctx, &gs); statusErr != nil {
+		if statusErr := r.persistStatus(ctx, &gs, origStatus); statusErr != nil {
 			logger.Error(statusErr, "failed to record ApplyFailed status")
 		}
 		return ctrl.Result{}, err
 	}
-	if result != controllerutil.OperationResultNone {
+	secretWritten := result != controllerutil.OperationResultNone
+	if secretWritten {
 		logger.Info("target Secret synced", "gitsecret", req.NamespacedName, "secret", targetName, "op", result)
 	}
 
 	gs.Status.ObservedGeneration = gs.Generation
 	gs.Status.SyncedKeys = len(data)
-	now := metav1.Now()
-	gs.Status.LastSyncTime = &now
 	r.setCondition(&gs, metav1.ConditionTrue, "Synced", fmt.Sprintf("decrypted %d key(s) into Secret/%s", len(data), targetName))
-	if err := r.Status().Update(ctx, &gs); err != nil {
-		return ctrl.Result{}, fmt.Errorf("update GitSecret status: %w", err)
+	// Refresh LastSyncTime only when this reconcile actually did something
+	// -- wrote the target Secret, or moved a status field. A steady-state
+	// reconcile (nothing drifted, spec unchanged) must not write, or the
+	// write re-triggers the next reconcile (see origStatus above).
+	if secretWritten || statusMeaningfullyChanged(origStatus, &gs.Status) {
+		now := metav1.Now()
+		gs.Status.LastSyncTime = &now
+		if err := r.Status().Update(ctx, &gs); err != nil {
+			return ctrl.Result{}, fmt.Errorf("update GitSecret status: %w", err)
+		}
 	}
 
 	return ctrl.Result{}, nil
+}
+
+// persistStatus writes gs.Status only if it differs from orig in a field
+// that matters (everything except LastSyncTime). It is how every failure
+// path records its condition without the write re-triggering the reconcile
+// on repeat -- an UnsealFailed object whose spec has not changed reconciles
+// once, writes the condition, and then stays quiet until something changes.
+func (r *GitSecretReconciler) persistStatus(ctx context.Context, gs *gitsecretv1alpha1.GitSecret, orig *gitsecretv1alpha1.GitSecretStatus) error {
+	if !statusMeaningfullyChanged(orig, &gs.Status) {
+		return nil
+	}
+	return r.Status().Update(ctx, gs)
+}
+
+// statusMeaningfullyChanged reports whether b differs from a in a way worth
+// persisting. LastSyncTime is deliberately excluded: it is only ever set
+// alongside a real change, so comparing it would defeat the point.
+func statusMeaningfullyChanged(a, b *gitsecretv1alpha1.GitSecretStatus) bool {
+	if a.ObservedGeneration != b.ObservedGeneration ||
+		a.SyncedKeys != b.SyncedKeys ||
+		a.RecipientCount != b.RecipientCount ||
+		a.SourceRevision != b.SourceRevision ||
+		!slices.Equal(a.Recipients, b.Recipients) {
+		return true
+	}
+	if len(a.Conditions) != len(b.Conditions) {
+		return true
+	}
+	for i := range a.Conditions {
+		x, y := a.Conditions[i], b.Conditions[i]
+		if x.Type != y.Type || x.Status != y.Status || x.Reason != y.Reason ||
+			x.Message != y.Message || x.ObservedGeneration != y.ObservedGeneration {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *GitSecretReconciler) setCondition(gs *gitsecretv1alpha1.GitSecret, status metav1.ConditionStatus, reason, message string) {

--- a/internal/controller/gitsecret_controller_test.go
+++ b/internal/controller/gitsecret_controller_test.go
@@ -260,6 +260,76 @@ func TestReconcile_RevertsDriftOnOwnedSecret(t *testing.T) {
 	}
 }
 
+// TestReconcile_SteadyStateStopsWritingStatus pins #77 item 1: once a
+// GitSecret is synced, reconciling it again with nothing changed must not
+// write status. An unconditional Status().Update returns through the
+// controller's own GitSecret watch and re-enqueues the object, so a
+// per-reconcile timestamp bump reconciles forever. The proxy for "did it
+// write" is the object's resourceVersion.
+func TestReconcile_SteadyStateStopsWritingStatus(t *testing.T) {
+	gnupgHome := shortTempDir(t)
+	fpr := genTestKey(t, gnupgHome)
+	t.Setenv("GNUPGHOME", gnupgHome)
+
+	spec, err := sealer.Seal("downtime", "downtime-secrets", map[string]string{"K": "v"}, []string{fpr})
+	if err != nil {
+		t.Fatalf("Seal: %v", err)
+	}
+	gs := &gitsecretv1alpha1.GitSecret{
+		ObjectMeta: metav1.ObjectMeta{Name: "downtime-secrets", Namespace: "downtime"},
+		Spec:       spec,
+	}
+	scheme := newScheme(t)
+	fakeClient := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(gs).
+		WithStatusSubresource(&gitsecretv1alpha1.GitSecret{}).
+		Build()
+
+	r := &GitSecretReconciler{Client: fakeClient}
+	req := ctrl.Request{NamespacedName: namespacedName("downtime", "downtime-secrets")}
+
+	// First reconcile: establishes the target Secret + status.
+	if _, err := r.Reconcile(context.Background(), req); err != nil {
+		t.Fatalf("initial Reconcile: %v", err)
+	}
+	var afterFirst gitsecretv1alpha1.GitSecret
+	if err := fakeClient.Get(context.Background(), req.NamespacedName, &afterFirst); err != nil {
+		t.Fatal(err)
+	}
+	rvAfterFirst := afterFirst.ResourceVersion
+	if afterFirst.Status.SyncedKeys != 1 {
+		t.Fatalf("first reconcile did not sync: status = %+v", afterFirst.Status)
+	}
+
+	// Several more reconciles with nothing changed -- the situation a
+	// self-triggered re-enqueue would create.
+	for i := 0; i < 5; i++ {
+		if _, err := r.Reconcile(context.Background(), req); err != nil {
+			t.Fatalf("steady-state Reconcile %d: %v", i, err)
+		}
+	}
+
+	var afterSteady gitsecretv1alpha1.GitSecret
+	if err := fakeClient.Get(context.Background(), req.NamespacedName, &afterSteady); err != nil {
+		t.Fatal(err)
+	}
+	if afterSteady.ResourceVersion != rvAfterFirst {
+		t.Errorf("steady-state reconcile wrote the object (resourceVersion %s -> %s); the status write re-triggers the reconcile loop",
+			rvAfterFirst, afterSteady.ResourceVersion)
+	}
+	// It must still report Ready -- quiet, not broken.
+	ready := false
+	for _, c := range afterSteady.Status.Conditions {
+		if c.Type == conditionReady && c.Status == metav1.ConditionTrue {
+			ready = true
+		}
+	}
+	if !ready {
+		t.Errorf("object lost its Ready condition after steady-state reconciles: %+v", afterSteady.Status.Conditions)
+	}
+}
+
 // TestReconcile_DoesNotClobberUnownedSecret: a Secret with the target name
 // already exists and is managed by something else (no owner reference back
 // to this GitSecret). Reconcile must leave it completely untouched and

--- a/internal/gpgutil/gpgutil.go
+++ b/internal/gpgutil/gpgutil.go
@@ -146,6 +146,14 @@ func Decrypt(ciphertext []byte) ([]byte, error) {
 // blob stays text-diffable, consistent with this codebase's existing
 // preference for text-safe encodings over raw binary.
 func Encrypt(plaintext []byte, recipients []string) ([]byte, error) {
+	return EncryptContext(context.Background(), plaintext, recipients)
+}
+
+// EncryptContext is Encrypt with a cancellation/deadline context -- the
+// gpg process is killed if ctx is done first. Used by callers that face
+// untrusted input on a request path (git-secret-seal ui) and must bound
+// how long a single seal can run.
+func EncryptContext(ctx context.Context, plaintext []byte, recipients []string) ([]byte, error) {
 	if len(recipients) == 0 {
 		return nil, fmt.Errorf("gpgutil: encrypt: no recipients given")
 	}
@@ -153,7 +161,7 @@ func Encrypt(plaintext []byte, recipients []string) ([]byte, error) {
 	for _, r := range recipients {
 		args = append(args, "--recipient", r)
 	}
-	out, err := run(plaintext, args...)
+	out, err := runCtx(ctx, plaintext, args...)
 	if err != nil {
 		return nil, fmt.Errorf("gpgutil: encrypt: %w", err)
 	}

--- a/internal/sealer/sealer.go
+++ b/internal/sealer/sealer.go
@@ -8,6 +8,7 @@
 package sealer
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/base64"
 	"fmt"
@@ -46,6 +47,12 @@ func aad(namespace, name, key string) []byte {
 // keybackend.GPGBackend's existing "config trusts pinned fingerprints
 // only" rule).
 func Seal(namespace, name string, data map[string]string, recipients []string) (v1alpha1.GitSecretSpec, error) {
+	return SealContext(context.Background(), namespace, name, data, recipients)
+}
+
+// SealContext is Seal with a context bounding the gpg wrap step -- for
+// callers on a request path facing untrusted input (git-secret-seal ui).
+func SealContext(ctx context.Context, namespace, name string, data map[string]string, recipients []string) (v1alpha1.GitSecretSpec, error) {
 	if len(recipients) == 0 {
 		return v1alpha1.GitSecretSpec{}, fmt.Errorf("sealer: no recipients given")
 	}
@@ -60,7 +67,7 @@ func Seal(namespace, name string, data map[string]string, recipients []string) (
 		return v1alpha1.GitSecretSpec{}, fmt.Errorf("sealer: generate content key: %w", err)
 	}
 
-	wrappedKey, err := gpgutil.Encrypt(key, recipients)
+	wrappedKey, err := gpgutil.EncryptContext(ctx, key, recipients)
 	if err != nil {
 		return v1alpha1.GitSecretSpec{}, fmt.Errorf("sealer: wrap content key: %w", err)
 	}

--- a/internal/webhook/setup.go
+++ b/internal/webhook/setup.go
@@ -11,39 +11,61 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-// InjectCABundle returns a manager.Runnable that patches
-// webhookConfigName's every webhook clientConfig.caBundle with caPEM, once
-// the manager's client is ready. The self-signed CA changes on every
-// controller restart, so this keeps the ValidatingWebhookConfiguration in
-// sync without cert-manager. Requires get/update on
-// validatingwebhookconfigurations.
-func InjectCABundle(mgr ctrl.Manager, webhookConfigName string, caPEM []byte) manager.Runnable {
-	return manager.RunnableFunc(func(ctx context.Context) error {
-		c := mgr.GetClient()
-		var cfg admissionregv1.ValidatingWebhookConfiguration
-		if err := c.Get(ctx, types.NamespacedName{Name: webhookConfigName}, &cfg); err != nil {
-			if apierrors.IsNotFound(err) {
-				// The chart may not have installed it (webhook disabled).
-				// Not fatal -- the handler simply never gets called.
-				ctrl.Log.WithName("webhook").Info("ValidatingWebhookConfiguration not found; skipping caBundle injection", "name", webhookConfigName)
-				return nil
-			}
-			return fmt.Errorf("webhook: get %s: %w", webhookConfigName, err)
-		}
-		changed := false
-		for i := range cfg.Webhooks {
-			if string(cfg.Webhooks[i].ClientConfig.CABundle) != string(caPEM) {
-				cfg.Webhooks[i].ClientConfig.CABundle = caPEM
-				changed = true
-			}
-		}
-		if !changed {
+// caBundleInjector patches webhookConfigName's clientConfig.caBundle with
+// caPEM once the manager's client is ready. The self-signed CA changes on
+// every controller restart, so this keeps the ValidatingWebhookConfiguration
+// in sync without cert-manager.
+//
+// It is a LeaderElectionRunnable that requires leadership: the CA it would
+// publish is this pod's own self-signed CA, and the ValidatingWebhook-
+// Configuration.caBundle holds exactly one. With more than one replica the
+// non-elected pods still serve the webhook with their own different certs,
+// so a shared cert (cert-manager, or a shared Secret) is the only way to run
+// the webhook HA -- until then the chart pins replicaCount: 1 whenever the
+// webhook is enabled. Gating on leadership at least keeps a mis-scaled
+// deployment from turning into a write-storm on the cluster-scoped config.
+type caBundleInjector struct {
+	mgr               ctrl.Manager
+	webhookConfigName string
+	caPEM             []byte
+}
+
+// NeedLeaderElection makes this run only on the elected leader.
+func (c *caBundleInjector) NeedLeaderElection() bool { return true }
+
+func (c *caBundleInjector) Start(ctx context.Context) error {
+	client := c.mgr.GetClient()
+	var cfg admissionregv1.ValidatingWebhookConfiguration
+	if err := client.Get(ctx, types.NamespacedName{Name: c.webhookConfigName}, &cfg); err != nil {
+		if apierrors.IsNotFound(err) {
+			// The chart may not have installed it (webhook disabled).
+			// Not fatal -- the handler simply never gets called.
+			ctrl.Log.WithName("webhook").Info("ValidatingWebhookConfiguration not found; skipping caBundle injection", "name", c.webhookConfigName)
 			return nil
 		}
-		if err := c.Update(ctx, &cfg); err != nil {
-			return fmt.Errorf("webhook: patch caBundle on %s: %w", webhookConfigName, err)
+		return fmt.Errorf("webhook: get %s: %w", c.webhookConfigName, err)
+	}
+	changed := false
+	for i := range cfg.Webhooks {
+		if string(cfg.Webhooks[i].ClientConfig.CABundle) != string(c.caPEM) {
+			cfg.Webhooks[i].ClientConfig.CABundle = c.caPEM
+			changed = true
 		}
-		ctrl.Log.WithName("webhook").Info("injected caBundle", "name", webhookConfigName)
+	}
+	if !changed {
 		return nil
-	})
+	}
+	if err := client.Update(ctx, &cfg); err != nil {
+		return fmt.Errorf("webhook: patch caBundle on %s: %w", c.webhookConfigName, err)
+	}
+	ctrl.Log.WithName("webhook").Info("injected caBundle", "name", c.webhookConfigName)
+	return nil
+}
+
+// InjectCABundle returns a leader-gated manager.Runnable that keeps
+// webhookConfigName's caBundle equal to caPEM. Requires get/update on
+// validatingwebhookconfigurations (the chart scopes update/patch to this
+// one config by name).
+func InjectCABundle(mgr ctrl.Manager, webhookConfigName string, caPEM []byte) manager.Runnable {
+	return &caBundleInjector{mgr: mgr, webhookConfigName: webhookConfigName, caPEM: caPEM}
 }

--- a/internal/webhook/setup_test.go
+++ b/internal/webhook/setup_test.go
@@ -1,0 +1,24 @@
+package webhook
+
+import (
+	"testing"
+
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// TestInjectCABundle_IsLeaderElected pins the fix for #77 item 2: the
+// caBundle injector must run only on the elected leader. Each replica
+// generates its own self-signed CA, and the ValidatingWebhookConfiguration
+// holds exactly one caBundle -- without leader gating, every replica races
+// to overwrite it with its own, a write-storm on a cluster-scoped object.
+func TestInjectCABundle_IsLeaderElected(t *testing.T) {
+	r := InjectCABundle(nil, "git-secret-controller", []byte("ca"))
+
+	ler, ok := r.(manager.LeaderElectionRunnable)
+	if !ok {
+		t.Fatal("InjectCABundle result does not implement manager.LeaderElectionRunnable")
+	}
+	if !ler.NeedLeaderElection() {
+		t.Fatal("caBundle injector must require leader election, got NeedLeaderElection() = false")
+	}
+}


### PR DESCRIPTION
## Summary

Executes the seven-item [#77](https://github.com/OpScaleHub/git-secret/issues/77) "Beta → GA hardening checklist" for `git-secret-controller`. Every item was re-validated against `main` (`0e51113`) before implementing; findings the audit downgraded (`Rewrap`, "consumer not owner", advisory hooks) are untouched. No cryptographic primitive, `Rewrap` semantic, or CRD schema change.

## Issue

Addresses #77 (do not auto-close — the issue tracks acceptance per item; close on merge if that matches the repo workflow).

## Changes

| #77 item | Result | Notes |
|---|---|---|
| 1 — reconcile self-trigger loop | **Fixed (code)** | The reconciler bumped `status.lastSyncTime` and `Status().Update`'d every pass; that write returns through its own watch and re-enqueues the object → a steady-state `GitSecret` reconciled forever. Now every status write is gated on `statusMeaningfullyChanged` (all fields except `lastSyncTime`); `lastSyncTime` is refreshed only when the reconcile wrote the Secret or moved a field. Failure paths go through `persistStatus` (same gate). Bounded at ≤2 reconciles per real change. **No watch predicate** — watch semantics untouched, zero risk of filtering a legitimate event. |
| 2 — webhook caBundle write-storm at `replicaCount > 1` | **Fixed (code + chart)** | `InjectCABundle` is now an explicit `LeaderElectionRunnable` (`caBundleInjector`, `NeedLeaderElection()=true`) — it was only *implicitly* leader-gated via controller-runtime's backwards-compat default. The chart now **refuses `webhook.enabled` with `replicaCount > 1`** (`helm` hard-fail with guidance): the serving cert is per-pod and the `caBundle` holds one CA, so multi-replica webhook needs a shared cert (cert-manager) that isn't wired yet. Reconcile HA via leader election is unaffected. |
| 3 — Secret RBAC scope + unused grants | **Fixed (chart + code)** | Dropped verbs the code never calls: `secrets: delete` (GC removes the owned Secret), `gitsecrets: update,patch` (only the status subresource is written). Scoped `validatingwebhookconfigurations` `update,patch` to the controller's own config via `resourceNames`. New `watchNamespaces` value → namespaced `Role`/`RoleBinding` per entry instead of the cluster-wide Secret grant, plus `--watch-namespaces` confining the manager cache (`cache.Options.DefaultNamespaces`). Default unchanged (cluster-wide — a GitSecret in any namespace materialises a Secret there; documented). |
| 4 — `v1alpha1` compat policy | **Docs** | New `UPGRADING.md`: versioning, the "additive only" contract for `v1alpha1` (no field meaning/type/default changes; a real change becomes a new version + migration note), upgrade/downgrade procedure. Linked from README, summarised in CHANGELOG. No API code change — the CRD stays single-version. |
| 5 — T11 wording | **Docs** | `threat-model.md` T11 "Handled" → "Partial (review aid + count check)" with the residual gap (constant-count substitution) spelled out; invariant #9 cross-references T11 + #40. `VerifyRecipients` unchanged — it does what it can cheaply do. |
| 6 — target Secret retained on unseal failure | **Docs** | `overview.md` now states the controller leaves the last-written Secret in place on `UnsealFailed` (fail-safe; a transient GPG issue must not pull a workload's secret), that this is not an access leak (K8s RBAC governs Secret reads, not the recipient list), and that deleting the `GitSecret` removes it. No behaviour change. |
| 7 — seal-UI NetworkPolicy + gpg cap | **Fixed (code + chart)** | `--max-inflight` (default 4) caps concurrent `/api/seal` via a semaphore (429 on overflow); each seal runs under a 30s deadline (`gpgutil.EncryptContext` / `sealer.SealContext` thread a context → `exec.CommandContext` kills the gpg child, no orphans; `Encrypt`/`Seal` keep their signatures). Recipient count capped at 64 (matches CRD `MaxItems`). Chart ships a `NetworkPolicy` locking egress to DNS; ingress restriction is opt-in (`sealUi.networkPolicy.allowFrom`) so `kubectl port-forward` + the kubelet probe keep working. `sealing-console.md` "port-forward is the boundary" softened to state the in-cluster reachability reality. |

## Tests

```
go build ./...                     # clean
go vet ./...                       # clean
gofmt -l .                         # clean
go test ./...                      # all packages pass
go test -race ./internal/controller/... ./internal/webhook/... \
  ./cmd/git-secret-seal/... ./cmd/git-secret-controller/... \
  ./internal/sealer/... ./internal/gpgutil/...   # clean
helm lint ./charts/git-secret-server ./charts/git-secret-controller   # 0 failed
helm template ./charts/git-secret-controller ...                      # renders (default, all-features, watchNamespaces)
helm template ... --set webhook.enabled=true --set replicaCount=2      # fails with the guard message (expected)
```

New tests:
- `internal/controller` — `TestReconcile_SteadyStateStopsWritingStatus` (resourceVersion unchanged across repeated no-op reconciles; Ready preserved).
- `internal/webhook` — `TestInjectCABundle_IsLeaderElected`.
- `cmd/git-secret-controller` — `TestParseWatchNamespaces`.
- `cmd/git-secret-seal` — `TestUI_SealConcurrencyCap` (429 at capacity, recovers when a slot frees), `TestUI_SealRejectsTooManyRecipients`.

GPG-dependent suites executed on this host (Linux + gpg present), not skipped.

## Security impact

- **RBAC**: strictly reduced. Removed `secrets: delete` and `gitsecrets: update/patch` (unused); `validatingwebhookconfigurations` `update/patch` now `resourceNames`-scoped so a compromised controller can't tamper with other webhook configs; opt-in `watchNamespaces` removes cluster-wide Secret access entirely. Default footprint unchanged and documented.
- **Webhook**: leader-gated CA injection + chart guard eliminate the multi-replica write-storm / cert-mismatch. No change to validation logic or `failurePolicy: Fail`.
- **seal-UI**: bounded gpg concurrency + per-request deadline (proper child-process termination) + recipient cap close an unauthenticated in-cluster DoS vector (availability only — the UI stays public-key-only, no decrypt, no persistence, no API access). Egress NetworkPolicy reduces exfil surface.
- No new logging of secret/key material. No privilege gained anywhere.

## Compatibility

- **Behaviour change**: `helm install/upgrade` now **hard-fails** `webhook.enabled=true` with `replicaCount > 1`. That combination was already broken (intermittent admission rejections); it now fails loudly with guidance. Single-replica webhook and multi-replica-without-webhook are unaffected.
- `status.lastSyncTime` now marks the last actual change, not the last reconcile pass (documented in the field's godoc). No schema change.
- New flags `--watch-namespaces`, `--max-inflight` are additive with safe defaults. `watchNamespaces: []` default = existing cluster-wide behaviour.
- CRD unchanged (single `v1alpha1`, served + stored). `UPGRADING.md` is the new written contract.
- RBAC verb removals are safe: the removed verbs correspond to no code path (verified against `internal/controller` and `internal/webhook`).

## Non-goals

- No cryptographic primitive redesign.
- No change to `Rewrap` semantics or content-key rotation.
- No reopening of the holistic audit (#75, CLOSED / signed off).
- No CRD schema change, no `failurePolicy` default change, no `spec.target.adopt` change.
