### PR TITLE
CI/CD & supply-chain hardening: pinned actions, provenance, signing, SBOM

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  # Keep the SHA-pinned GitHub Actions current -- Dependabot bumps the pin
+  # and rewrites the trailing "# vX.Y.Z" comment.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      go-deps:
+        patterns: ["*"]
+
+  # Base-image digests in the Dockerfiles.
+  - package-ecosystem: docker
+    directories:
+      - /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,8 @@ jobs:
       # merge's diff).
       code: ${{ steps.filter.outputs.code == 'true' || github.event_name == 'push' }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: dorny/paths-filter@v3
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: dorny/paths-filter@0e4a8c6effa4802afeda77dc8d303f8176d7dfad # v3.0.4
         id: filter
         with:
           filters: |
@@ -30,7 +30,8 @@ jobs:
               - 'charts/**'
               - 'config/**'
               - 'Dockerfile*'
-              - '.github/workflows/ci.yml'
+              - '.github/workflows/**'
+              - '.github/dependabot.yml'
 
   test:
     name: Build, vet, test
@@ -43,10 +44,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.25'
 
@@ -61,8 +62,47 @@ jobs:
       - name: Vet
         run: go vet ./...
 
-      - name: Test
+      # Linux: the GPG-dependent suites must actually execute (not silently
+      # t.Skip -- see internal/gpgutil TestGPGSuiteFloor), and we run the
+      # race detector here. macOS/Windows skip the GPG suites by design.
+      - name: Test (Linux — race + GPG required)
+        if: runner.os == 'Linux'
+        env:
+          REQUIRE_GPG_TESTS: '1'
+        run: go test ./... -race -v
+
+      - name: Test (macOS / Windows)
+        if: runner.os != 'Linux'
         run: go test ./... -v
+
+  security-scan:
+    name: Vulnerability & config scan (advisory)
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
+        with:
+          go-version: '1.25'
+
+      - name: govulncheck
+        continue-on-error: true # advisory for now
+        run: go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...
+
+      - name: Trivy (filesystem — vuln, misconfig, secret)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        continue-on-error: true # advisory for now
+        with:
+          scan-type: fs
+          scanners: vuln,misconfig,secret
+          severity: HIGH,CRITICAL
+          exit-code: '1'
 
   chart:
     name: Lint & render Helm chart
@@ -71,10 +111,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
       - name: helm lint
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     tags:
       - 'v*' # Trigger on version tags like v1.0.0, v0.1.0
 
+# Default-deny: every job below re-declares exactly the scopes it needs, so
+# a job added later starts with nothing rather than inheriting the repo/org
+# default token scope.
+permissions: {}
+
 jobs:
   # Client-side tools only: git-secret, kubectl-secret, git-secret-seal --
   # things a human or a CI job runs directly on their own machine, so a
@@ -20,6 +25,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write # Needed to create releases
+      id-token: write # keyless signing / provenance attestations
+      attestations: write # actions/attest-build-provenance
 
     strategy:
       matrix:
@@ -31,10 +38,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.25' # must match the `go` directive in go.mod
 
@@ -86,8 +93,21 @@ jobs:
           sha256sum "${{ env.KUBECTL_ASSET_PATH }}" > "${{ env.KUBECTL_ASSET_PATH }}.sha256"
           sha256sum "${{ env.SEAL_ASSET_PATH }}" > "${{ env.SEAL_ASSET_PATH }}.sha256"
 
+      # SLSA build provenance: a signed statement (GitHub's Fulcio-backed
+      # OIDC identity) that these exact bytes were produced by this workflow
+      # at this commit. Verify with `gh attestation verify <file> --repo
+      # OpScaleHub/git-secret`. Unlike the .sha256 sidecars, this cannot be
+      # forged by whoever can edit the release assets.
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: |
+            ${{ env.ASSET_PATH }}
+            ${{ env.KUBECTL_ASSET_PATH }}
+            ${{ env.SEAL_ASSET_PATH }}
+
       - name: Upload Release Asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
@@ -113,6 +133,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      id-token: write
+      attestations: write
 
     strategy:
       matrix:
@@ -120,10 +142,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.25'
 
@@ -151,8 +173,15 @@ jobs:
           sha256sum "${{ env.SERVER_ASSET_PATH }}" > "${{ env.SERVER_ASSET_PATH }}.sha256"
           sha256sum "${{ env.CONTROLLER_ASSET_PATH }}" > "${{ env.CONTROLLER_ASSET_PATH }}.sha256"
 
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: |
+            ${{ env.SERVER_ASSET_PATH }}
+            ${{ env.CONTROLLER_ASSET_PATH }}
+
       - name: Upload Release Asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
@@ -160,6 +189,25 @@ jobs:
             ${{ env.SERVER_ASSET_PATH }}.sha256
             ${{ env.CONTROLLER_ASSET_PATH }}
             ${{ env.CONTROLLER_ASSET_PATH }}.sha256
+
+  # One SPDX SBOM of the module graph, attached to the release. The
+  # container images carry their own (finer-grained) SBOM attestation from
+  # the build-push step below. sbom-action auto-attaches to the release on
+  # a tag push.
+  sbom:
+    name: Generate release SBOM
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # attach the SBOM asset to the release
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Generate + attach SBOM
+        uses: anchore/sbom-action@3ad7283483fc7af8ff2b4ea19663c2d5ca935e26 # v0.24.2
+        with:
+          path: .
+          artifact-name: git-secret-sbom.spdx.json
 
   # git-secret-server is a DEPRECATED component (superseded by the GitSecret
   # CRD + git-secret-controller). Its image and chart are still published so
@@ -170,10 +218,12 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write # Needed to push to GHCR
+      packages: write # push to GHCR
+      id-token: write # keyless cosign signing (OIDC)
+      attestations: write # provenance/SBOM attestations
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Validate tag
         env:
@@ -197,36 +247,54 @@ jobs:
         run: echo "OWNER_LC=$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          # SLSA provenance + SBOM attestations attached to the image in
+          # the registry (OCI referrers). Verify provenance with
+          # `cosign verify-attestation --type slsaprovenance ...`.
+          provenance: mode=max
+          sbom: true
           build-args: |
             VERSION=${{ github.ref_name }}
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/git-secret-server:${{ github.ref_name }}
             ghcr.io/${{ env.OWNER_LC }}/git-secret-server:latest
 
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            "ghcr.io/${OWNER_LC}/git-secret-server@${DIGEST}"
+
   docker-release-controller:
     name: Build & push git-secret-controller image
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      packages: write # Needed to push to GHCR
+      packages: write # push to GHCR
+      id-token: write # keyless cosign signing (OIDC)
+      attestations: write # provenance/SBOM attestations
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Validate tag
         env:
@@ -241,27 +309,40 @@ jobs:
         run: echo "OWNER_LC=$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@7e8b541eb2e61bf99390e1afd4be13a184e9ebc5 # v3.10.1
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        id: build
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           file: Dockerfile.controller
           push: true
           platforms: linux/amd64,linux/arm64
+          provenance: mode=max
+          sbom: true
           build-args: |
             VERSION=${{ github.ref_name }}
           tags: |
             ghcr.io/${{ env.OWNER_LC }}/git-secret-controller:${{ github.ref_name }}
             ghcr.io/${{ env.OWNER_LC }}/git-secret-controller:latest
+
+      - name: Sign image (keyless)
+        env:
+          DIGEST: ${{ steps.build.outputs.digest }}
+        run: |
+          cosign sign --yes \
+            "ghcr.io/${OWNER_LC}/git-secret-controller@${DIGEST}"
 
   chart-release:
     name: Package & push Helm chart
@@ -271,7 +352,7 @@ jobs:
       packages: write # Needed to push to GHCR (OCI)
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Validate tag
         env:
@@ -289,7 +370,7 @@ jobs:
         run: echo "OWNER_LC=$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin
@@ -317,7 +398,7 @@ jobs:
       packages: write # Needed to push to GHCR (OCI)
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
 
       - name: Validate tag
         env:
@@ -332,7 +413,7 @@ jobs:
         run: echo "OWNER_LC=$(printf '%s' '${{ github.repository_owner }}' | tr '[:upper:]' '[:lower:]')" >> "$GITHUB_ENV"
 
       - name: Set up Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
       - name: Log in to GHCR
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # internal/decryptserver for the request/response contract and the
 # README's "git-secret-server" section for deployment.
 
-FROM golang:1.25-bookworm AS build
+FROM golang:1.25-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -17,7 +17,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=${VERSION}"
 # internal/gitutil.CloneContext and internal/gpgutil) — so this can't
 # be a from-scratch/distroless-static image the way a pure-Go binary
 # normally could be.
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
         gnupg \

--- a/Dockerfile.controller
+++ b/Dockerfile.controller
@@ -2,7 +2,7 @@
 # plain Kubernetes Secrets. See internal/controller for the reconcile
 # logic and the README's "GitSecret CRD" section for deployment.
 
-FROM golang:1.25-bookworm AS build
+FROM golang:1.25-bookworm@sha256:3b4a11519ad929d1e1d261a12cff056f0c85b735253d7d861346b9c6f8b36437 AS build
 WORKDIR /src
 COPY go.mod go.sum ./
 RUN go mod download
@@ -21,7 +21,7 @@ RUN CGO_ENABLED=0 go build -trimpath -ldflags="-s -w -X main.version=${VERSION}"
 # -- so this can't be a from-scratch/distroless-static image. Unlike
 # git-secret-server, this controller never clones a repository, so
 # neither git nor an SSH client is needed here at all.
-FROM debian:bookworm-slim
+FROM debian:bookworm-slim@sha256:88200866dfff7ea7f5cbcb6ec7c8a701889efe6fe859fe64d6990e4b07ea4171
 RUN apt-get update && apt-get install -y --no-install-recommends \
         gnupg \
         ca-certificates \

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -42,3 +42,38 @@ The latest tagged release. `git-secret-server` receives security fixes only; the
 We aim to acknowledge a report within a few working days and to agree a
 coordinated disclosure timeline from there. Reporters are credited in the advisory
 unless they ask not to be.
+
+## Verifying a release
+
+Every tagged release carries cryptographic provenance in addition to the
+`.sha256` sidecars (which prove integrity, not authenticity).
+
+**Binaries** — SLSA build provenance, signed with GitHub's OIDC identity:
+
+```
+gh attestation verify ./git-secret-linux-amd64 --repo OpScaleHub/git-secret
+```
+
+**Container images** — signed with keyless [cosign](https://docs.sigstore.dev/),
+plus provenance + SBOM attestations:
+
+```
+cosign verify \
+  --certificate-identity-regexp '^https://github.com/OpScaleHub/git-secret/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/opscalehub/git-secret-controller:<tag>
+
+cosign verify-attestation --type slsaprovenance \
+  --certificate-identity-regexp '^https://github.com/OpScaleHub/git-secret/' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  ghcr.io/opscalehub/git-secret-controller:<tag>
+```
+
+**SBOM** — an SPDX SBOM of the module graph (`git-secret-sbom.spdx.json`) is
+attached to each GitHub release; the images carry their own finer-grained SBOM
+attestation (`cosign download sbom ...` / `--type spdxjson`).
+
+All CI/release workflows pin every third-party action to a commit SHA
+(`.github/dependabot.yml` keeps the pins current) and run with a default-deny
+token (`permissions: {}` at the workflow root, each job re-declaring only what it
+needs).

--- a/internal/gpgutil/gpgfloor_test.go
+++ b/internal/gpgutil/gpgfloor_test.go
@@ -1,0 +1,48 @@
+package gpgutil
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestGPGSuiteFloor is the guard for #78 item 6. The GPG-dependent suites
+// across this repo all `t.Skip` when gpg is missing, on Windows, or when
+// unattended key generation fails -- so a broken gpg/gpg-agent on a runner
+// silently turns every real assertion into a skip while CI still reports
+// green.
+//
+// When REQUIRE_GPG_TESTS=1 (set by CI on the Linux matrix leg only), this
+// test refuses to skip: if gpg is not actually usable end-to-end here, it
+// fails, and the "GPG suite didn't really run" condition becomes visible.
+// Everywhere else it is a normal skip.
+func TestGPGSuiteFloor(t *testing.T) {
+	required := os.Getenv("REQUIRE_GPG_TESTS") == "1"
+
+	fail := func(format string, args ...any) {
+		if required {
+			t.Fatalf("REQUIRE_GPG_TESTS=1 but "+format, args...)
+		}
+		t.Skipf(format, args...)
+	}
+
+	if !Available() {
+		fail("gpg binary not found on PATH")
+	}
+
+	home := shortTempDir(t)
+	t.Setenv("GNUPGHOME", home)
+	cmd := exec.Command(Binary, "--batch", "--passphrase", "", "--quick-generate-key",
+		"GPG Floor <gpg-floor@example.invalid>", "default", "default", "never")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		fail("gpg cannot generate a key unattended: %v: %s", err, stderr.String())
+	}
+
+	keys, err := ListSecretKeys()
+	if err != nil || len(keys) == 0 {
+		fail("gpg generated a key but it could not be listed back: err=%v keys=%d", err, len(keys))
+	}
+}


### PR DESCRIPTION
## Summary

Addresses **#78** — CI/CD & supply-chain hardening. Pipeline + Dockerfiles + one guard test + SECURITY.md. **No application/runtime code change; nothing about what is built or published changes.**

## Issue

Addresses #78 (close on merge if that matches the repo workflow).

## Changes

| #78 item | Result | Verified how |
|---|---|---|
| 1 — pin actions to SHA | **Done** — every `uses:` in `ci.yml` + `release.yml` is a commit SHA with a `# vX.Y.Z` comment. `actions/checkout` → v5, `actions/setup-go` → v6. New `.github/dependabot.yml` (github-actions, gomod, docker). | CI green on this PR |
| 2 — top-level `permissions` in `release.yml` | **Done** — `permissions: {}` at workflow root; each job re-declares its scopes. | YAML parse + review (tag-triggered) |
| 3 — sign artifacts + provenance + SBOM | **Done (review-only)** — `actions/attest-build-provenance` on every binary job; `docker/build-push-action` `provenance: mode=max` + `sbom: true`; keyless `cosign sign` per image; a `sbom` job attaches an SPDX module SBOM. `SECURITY.md` gains a "Verifying a release" section. | YAML parse + review; **not** run (release.yml only fires on tags) |
| 4 — base-image digests + scanning | **Done** — `golang:1.25-bookworm` / `debian:bookworm-slim` pinned by `@sha256` in both Dockerfiles; `govulncheck` + Trivy fs scan added to `ci.yml` (advisory / `continue-on-error`). | `docker build` both images locally; `govulncheck ./...` locally → 0 called vulns |
| 5 — Node 20 annotation | **Partial** — resolved for `checkout`/`setup-go` (the bulk) by the v5/v6 bump. `dorny/paths-filter` + `azure/setup-helm` stay node20 until upstream ships node24 majors; noted, not chased (P2 cosmetic). | — |
| 6 — GPG-suite floor + `-race` | **Done** — `internal/gpgutil.TestGPGSuiteFloor` fails (instead of skipping) when `REQUIRE_GPG_TESTS=1` and gpg isn't usable end-to-end; CI sets that on the Linux leg, which also runs `-race`. | `REQUIRE_GPG_TESTS=1 go test ./... -race` locally — clean |

## Tests / verification

```
go build ./... ; go vet ./... ; gofmt -l .            # clean
REQUIRE_GPG_TESTS=1 go test ./... -race                # all packages pass, no races
go test ./internal/gpgutil -run TestGPGSuiteFloor      # pass (with and without REQUIRE_GPG_TESTS=1)
docker build -f Dockerfile . ; docker build -f Dockerfile.controller .   # both build on pinned digests
go run golang.org/x/vuln/cmd/govulncheck@v1.7.0 ./...  # 0 vulnerabilities in called code
python3 -c "import yaml; ..."                          # ci.yml + release.yml + dependabot.yml parse
```

CI on this PR exercises: the SHA-pinned actions, `checkout@v5` + `setup-go@v6`, the new `-race` + `REQUIRE_GPG_TESTS=1` Linux leg, the advisory `security-scan` job (govulncheck + Trivy), and the Dockerfile digest pins (via the chart/helm + build steps).

**Not exercised by CI** (only runs on a `v*` tag): the `release.yml` signing / attestation / SBOM / cosign steps. These are added per the action docs with correct permissions (`id-token: write`, `attestations: write`) and reviewed; the first tagged release after merge is the real test. All contained to the release workflow — a failure there does not affect `main` or CI.

## Security impact

- Release pipeline can no longer be hijacked via a repointed action tag (SHA pins) and starts from a default-deny token.
- A consumer can now cryptographically verify a downloaded binary (`gh attestation verify`) or a pulled image (`cosign verify`) is the artifact this repo built — the `.sha256` sidecars only ever proved integrity.
- Reproducible image builds (digest-pinned bases); dependency + vuln drift now surfaces on every PR.

## Compatibility

- `checkout@v5` / `setup-go@v6` are drop-in on GitHub-hosted runners (node24). No workflow logic depends on removed behaviour.
- New `security-scan` CI job is advisory (`continue-on-error`) and **not** wired into the `ci-status` required check — it never blocks a merge.
- `govulncheck@v1.7.0` triggers an automatic Go toolchain fetch (its go.mod needs ≥1.25); adds ~30s to the advisory job only.

## Non-goals

- No change to what is built or published. `git-secret-server` stays published (deprecated, not deleted).
- No application/runtime code change.
- No reopening of the holistic audit (#75).
