### PR TITLE
ci: isolate the Kubernetes dependency stack in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,20 @@ updates:
     schedule:
       interval: weekly
     groups:
+      # The Kubernetes client/controller-runtime stack is kept in its own
+      # group: a bump there typically raises the go.mod `go` directive and
+      # carries controller-runtime API changes, so it needs a deliberate PR
+      # (bump CI's setup-go go-version, re-verify internal/controller +
+      # internal/webhook) rather than riding along with routine updates.
+      kubernetes:
+        patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
       go-deps:
         patterns: ["*"]
+        exclude-patterns:
+          - "k8s.io/*"
+          - "sigs.k8s.io/*"
 
   # Base-image digests in the Dockerfiles.
   - package-ecosystem: docker


### PR DESCRIPTION
## Why

Dependabot PR #83 (`go-deps` group) can't merge: it bundles routine updates with **k8s.io/\* v0.34 → v0.37** and **controller-runtime v0.22 → v0.24**, which:

- raises the `go.mod` `go` directive to **1.26** → CI's `setup-go` is pinned to `1.25` → `go build` fails (`go.mod requires go >= 1.26.0`), and
- brings controller-runtime API changes that need `internal/controller` + `internal/webhook` re-verified (the reconcile predicate / cache / webhook-server wiring hardened in #77).

That's a deliberate upgrade, not a ride-along.

## Change

Split the `gomod` config into two groups:

- **`kubernetes`** — `k8s.io/*`, `sigs.k8s.io/*` → its own PR, handled when someone does the upgrade (bump the workflow `go-version`, re-run the controller/webhook verification).
- **`go-deps`** — everything else, so `golang.org/x/crypto` and friends keep flowing.

Config only — `dependabot.yml` is not executed. After this merges, Dependabot recomputes on its next run and supersedes #83.

https://claude.ai/code/session_01HKyySmPYGKLGT3Zqj5A5GT