### PR TITLE
docs(landing): describe GitSecret on its own terms, drop competitor name-drops

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>git-secret — plaintext on disk, ciphertext in history</title>
 <meta name="description" content="git-secret transparently encrypts pattern-matched files in a git repository via installed hooks — modern AEAD crypto, no GPG required, one cross-platform binary. Ships GitSecret: a native Kubernetes CRD and controller with ciphertext inline in the object and no repo clone at all. No third-party secret store." />
-<meta name="keywords" content="git-secret, secrets management, git encryption, GitOps secrets, Kubernetes secrets, ArgoCD, kubectl plugin, GPG, AEAD encryption, Custom Resource Definition, Kubernetes controller, sealed-secrets" />
+<meta name="keywords" content="git-secret, secrets management, git encryption, GitOps secrets, Kubernetes secrets, ArgoCD, kubectl plugin, GPG, AEAD encryption, Custom Resource Definition, Kubernetes controller" />
 <meta name="robots" content="index, follow" />
 <meta name="author" content="OpScaleHub" />
 <meta name="theme-color" content="#10151A" />
@@ -486,7 +486,7 @@
         </div>
         <div class="step">
           <span class="step-no">3</span>
-          <div><h3>pre-push</h3><p>Runs the same check as <code>verify</code> against <code>HEAD</code> and blocks the push if a bypassed <code>pre-commit</code> ever let plaintext through.</p></div>
+          <div><h3>pre-push</h3><p>Runs <code>verify</code> over the whole range you're about to push — not just <code>HEAD</code> — and blocks it if a bypassed <code>pre-commit</code> ever let plaintext through.</p></div>
         </div>
       </div>
     </div>
@@ -643,7 +643,7 @@ gpg_recipients:
       <div class="section-head">
         <p class="eyebrow">Beyond the CLI</p>
         <h2>GitSecret: a native CRD, ciphertext inline, no clone at all</h2>
-        <p class="lede"><code>GitSecret</code> is a custom resource with its own controller — modeled on Bitnami <code>sealed-secrets</code>' shape, built on this project's existing multi-recipient GPG cryptography rather than one controller keypair. Ciphertext lives inline in the object, delivered by whatever already applies your manifests — ArgoCD, <code>kubectl apply</code> — with no repo clone, no SSH transport, and no network hop anywhere in the decrypt path.</p>
+        <p class="lede"><code>GitSecret</code> is a custom resource with its own controller. Ciphertext lives inline in the object — no external store, no repo clone in the cluster, no SSH transport, no network hop anywhere in the decrypt path — delivered by whatever already applies your manifests (ArgoCD, <code>kubectl apply</code>) and decrypted in-cluster by a controller holding one of the GPG keys it's wrapped to.</p>
         <p class="lede">The point isn't "GPG instead of a single keypair" — it's <strong>recovery independence</strong>: losing the cluster, the controller, or any one key doesn't make the secrets unrecoverable, as long as the encrypted repo and one authorized recipient key survive. See the <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret/blob/main/docs/security/threat-model.md" target="_blank" rel="noopener">threat model</a> and <a class="footnote-link" href="https://github.com/OpScaleHub/git-secret/blob/main/docs/security/disaster-recovery.md" target="_blank" rel="noopener">disaster-recovery runbooks</a>.</p>
       </div>
 
@@ -669,7 +669,7 @@ gpg_recipients:
         </div>
         <div class="ledger-entry">
           <span class="ledger-code">MULTI-KEY</span>
-          <div><h3>Not one controller keypair</h3><p>The content key wraps to as many GPG recipients as you want — the controller's own identity, and independently, any number of humans or backups. <code>--rewrap</code> re-encrypts only that wrapped key when a recipient is added or removed; every value's ciphertext is untouched, and a newly-added recipient decrypts independently, with no involvement from the key that did the rewrapping.</p></div>
+          <div><h3>Wrapped to every recipient you choose</h3><p>The content key wraps to as many GPG recipients as you want — the controller's own identity, and independently, any number of humans or offline backups. <code>--rewrap</code> re-encrypts only that wrapped key when a recipient is added or removed; every value's ciphertext is untouched, and a newly-added recipient decrypts independently, with no involvement from the key that did the rewrapping.</p></div>
         </div>
         <div class="ledger-entry">
           <span class="ledger-code">BOUND</span>


### PR DESCRIPTION
## Why

The landing page named a competitor (Bitnami sealed-secrets) three times and framed `GitSecret` as derivative of it — *"modeled on Bitnami `sealed-secrets`' shape … rather than one controller keypair"*, plus a feature heading *"Not one controller keypair"* and a `<meta keywords>` entry. That's free mindshare for a competitor and only reads well if you already know their internals. Not smart branding.

## Changes (`docs/index.html` only)

| Spot | Before | After |
|---|---|---|
| `#crd` lede | "a custom resource with its own controller — **modeled on Bitnami `sealed-secrets`' shape**, built on … **rather than one controller keypair**. Ciphertext lives inline…" | "a custom resource with its own controller. Ciphertext lives inline in the object — no external store, no repo clone in the cluster, no SSH transport, no network hop in the decrypt path — delivered by whatever already applies your manifests (ArgoCD, `kubectl apply`) and decrypted in-cluster by a controller holding one of the GPG keys it's wrapped to." |
| MULTI-KEY heading | "Not one controller keypair" | "Wrapped to every recipient you choose" |
| `<meta keywords>` | `…, Kubernetes controller, sealed-secrets` | `…, Kubernetes controller` |
| `#how` pre-push (accuracy, unrelated) | "Runs the same check as `verify` against `HEAD`" | "Runs `verify` over the whole range you're about to push — not just `HEAD`" |

No competitor is named anywhere on the page now. The differentiators that carry the section — no clone, no network hop, recovery independence, per-object AAD binding — are unchanged. HTML validated (balanced tags).

Left in place deliberately: "no third-party secret store" in the meta/OG description — it names nobody and is a genuine architectural property.

https://claude.ai/code/session_01HKyySmPYGKLGT3Zqj5A5GT